### PR TITLE
feat: continuous 3D surface zigzag movement and scan direction config

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -345,7 +345,8 @@ function updateStrategyUI() {
   zigzagOptions.style.display = strategy === 'zigzag' ? 'block' : 'none';
 }
 
-strategySelect.addEventListener('change', updateStrategyUI);
+strategySelect.addEventListener('change', () => { updateStrategyUI(); tryPreview(); });
+document.getElementById('scan-direction').addEventListener('change', tryPreview);
 updateStrategyUI();
 
 // ── Tabs ─────────────────────────────────────────────────────────────

--- a/www/index.html
+++ b/www/index.html
@@ -216,6 +216,14 @@ canvas { flex: 1; width: 100%; height: 100%; display: block; }
       <label>Step-over (mm)</label>
       <input type="number" id="step-over" value="1.5" step="0.1" min="0.1"/>
     </section>
+    <section id="zigzag-options" style="display:none;">
+      <h2>Zigzag Options</h2>
+      <label>Scan direction</label>
+      <select id="scan-direction">
+        <option value="x">X (rows along X)</option>
+        <option value="y">Y (rows along Y)</option>
+      </select>
+    </section>
     <section id="perimeter-options" style="display:none;">
       <h2>Perimeter Options</h2>
       <label>
@@ -329,10 +337,12 @@ document.getElementById('tool-diameter').addEventListener('change', updateToolTy
 // ── Strategy UI ───────────────────────────────────────────────────────
 const strategySelect = document.getElementById('strategy');
 const perimeterOptions = document.getElementById('perimeter-options');
+const zigzagOptions = document.getElementById('zigzag-options');
 
 function updateStrategyUI() {
   const strategy = strategySelect.value;
   perimeterOptions.style.display = strategy === 'perimeter' ? 'block' : 'none';
+  zigzagOptions.style.display = strategy === 'zigzag' ? 'block' : 'none';
 }
 
 strategySelect.addEventListener('change', updateStrategyUI);
@@ -418,6 +428,10 @@ function getConfig() {
     config.corner_radius = parseFloat(document.getElementById('corner-radius').value) || 0;
   } else if (toolType === 'face_mill') {
     config.effective_diameter = parseFloat(document.getElementById('effective-diameter').value) || config.tool_diameter;
+  }
+  // Add zigzag-specific parameters
+  if (config.strategy === 'zigzag') {
+    config.scan_direction = document.getElementById('scan-direction').value;
   }
   // Add perimeter-specific parameters
   if (config.strategy === 'perimeter') {


### PR DESCRIPTION
Rework ZigzagSurfaceStrategy to eliminate retracts between rows - the tool
now stays on the surface cutting directly from one row to the next, producing
a continuous back-and-forth 3D surface finish. Add scan_direction (X/Y) config
option wired through CamConfig, lib.rs, and a new Zigzag Options UI section.

https://claude.ai/code/session_016DiuPEQTaKiBtSA2M9vR1k