### PR TITLE
Add G-code generation progress indicator with Web Worker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 wasm-bindgen = "0.2"
+js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ use toolpath::{
     ToolpathStrategy, ZigzagSurfaceStrategy,
 };
 use wasm_bindgen::prelude::*;
+use js_sys::Function;
 
 // ── Public parameter struct (JSON from JS) ───────────────────────────
 
@@ -301,6 +302,168 @@ pub fn process_svg(svg_text: &str, config_json: &str) -> Result<String, JsValue>
         let mut p = cut_params.clone();
         p.cut_z = z;
         all_toolpaths.extend(strategy.generate(&polylines, &p));
+        if (z - config.cut_depth).abs() < 0.001 {
+            break;
+        }
+    }
+
+    Ok(emit_gcode(&all_toolpaths, &gcode_params))
+}
+
+/// Helper: call a JS progress callback with (completed, total).
+fn report_progress(cb: &Function, completed: u32, total: u32) {
+    let _ = cb.call2(
+        &JsValue::NULL,
+        &JsValue::from(completed),
+        &JsValue::from(total),
+    );
+}
+
+/// Process an STL file with progress reporting.
+/// The callback receives (completed_layers, total_layers) after each layer.
+#[wasm_bindgen]
+pub fn process_stl_progress(
+    data: &[u8],
+    config_json: &str,
+    on_progress: &Function,
+) -> Result<String, JsValue> {
+    let config: CamConfig =
+        serde_json::from_str(config_json).map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+    let mesh = stl::parse_stl(data).map_err(|e| JsValue::from_str(&e))?;
+
+    let cut_params = CutParams {
+        tool: tool_from_config(&config),
+        tool_diameter: config.tool_diameter,
+        step_over: config.step_over,
+        step_down: config.step_down,
+        feed_rate: config.feed_rate,
+        plunge_rate: config.plunge_rate,
+        safe_z: config.safe_z,
+        cut_z: config.cut_depth,
+        climb_cut: config.climb_cut,
+        perimeter_passes: config.perimeter_passes,
+    };
+
+    let gcode_params = GcodeParams {
+        feed_rate: config.feed_rate,
+        plunge_rate: config.plunge_rate,
+        spindle_speed: config.spindle_speed,
+        safe_z: config.safe_z,
+        unit_mm: true,
+    };
+
+    let toolpaths: Vec<Toolpath> = match config.strategy.as_str() {
+        "zigzag" => {
+            report_progress(on_progress, 0, 1);
+            let strategy = ZigzagSurfaceStrategy;
+            let surface_params =
+                SurfaceParams::new(&mesh, cut_params, scan_direction_from_config(&config));
+            let result = strategy.generate_surface(&surface_params);
+            report_progress(on_progress, 1, 1);
+            result
+        }
+        other => {
+            let layers = slicer::slice_mesh(&mesh, config.step_down);
+            let total = layers.len() as u32;
+            report_progress(on_progress, 0, total);
+            let strategy: Box<dyn ToolpathStrategy> = match other {
+                "pocket" => Box::new(PocketStrategy),
+                "perimeter" => Box::new(PerimeterStrategy),
+                "slice" => Box::new(ContourStrategy),
+                _ => Box::new(ContourStrategy),
+            };
+            let mut all = Vec::new();
+            for (i, (z, contours)) in layers.iter().enumerate() {
+                let mut p = cut_params.clone();
+                p.cut_z = *z;
+                all.extend(strategy.generate(contours, &p));
+                report_progress(on_progress, (i + 1) as u32, total);
+            }
+            if all.is_empty() && other != "pocket" && other != "perimeter" {
+                let contours = slicer::slice_at_z(
+                    &mesh,
+                    mesh.bounds.as_ref().map_or(0.0, |b| b.min.z + 0.01),
+                );
+                all.extend(strategy.generate(&contours, &cut_params));
+            }
+            all
+        }
+    };
+
+    Ok(emit_gcode(&toolpaths, &gcode_params))
+}
+
+/// Process an SVG string with progress reporting.
+/// The callback receives (completed_layers, total_layers) after each layer.
+#[wasm_bindgen]
+pub fn process_svg_progress(
+    svg_text: &str,
+    config_json: &str,
+    on_progress: &Function,
+) -> Result<String, JsValue> {
+    let config: CamConfig =
+        serde_json::from_str(config_json).map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+    let polylines = svg::parse_svg(svg_text).map_err(|e| JsValue::from_str(&e))?;
+
+    let cut_params = CutParams {
+        tool: tool_from_config(&config),
+        tool_diameter: config.tool_diameter,
+        step_over: config.step_over,
+        step_down: config.step_down,
+        feed_rate: config.feed_rate,
+        plunge_rate: config.plunge_rate,
+        safe_z: config.safe_z,
+        cut_z: config.cut_depth,
+        climb_cut: config.climb_cut,
+        perimeter_passes: config.perimeter_passes,
+    };
+
+    let gcode_params = GcodeParams {
+        feed_rate: config.feed_rate,
+        plunge_rate: config.plunge_rate,
+        spindle_speed: config.spindle_speed,
+        safe_z: config.safe_z,
+        unit_mm: true,
+    };
+
+    let strategy: Box<dyn ToolpathStrategy> = match config.strategy.as_str() {
+        "pocket" => Box::new(PocketStrategy),
+        "perimeter" => Box::new(PerimeterStrategy),
+        _ => Box::new(ContourStrategy),
+    };
+
+    // Count total layers
+    let mut total_layers = 0u32;
+    {
+        let mut z = 0.0;
+        while z > config.cut_depth - 0.001 {
+            z -= config.step_down;
+            if z < config.cut_depth {
+                z = config.cut_depth;
+            }
+            total_layers += 1;
+            if (z - config.cut_depth).abs() < 0.001 {
+                break;
+            }
+        }
+    }
+    report_progress(on_progress, 0, total_layers);
+
+    let mut all_toolpaths = Vec::new();
+    let mut z = 0.0;
+    let mut layer_num = 0u32;
+    while z > config.cut_depth - 0.001 {
+        z -= config.step_down;
+        if z < config.cut_depth {
+            z = config.cut_depth;
+        }
+        let mut p = cut_params.clone();
+        p.cut_z = z;
+        all_toolpaths.extend(strategy.generate(&polylines, &p));
+        layer_num += 1;
+        report_progress(on_progress, layer_num, total_layers);
         if (z - config.cut_depth).abs() < 0.001 {
             break;
         }

--- a/www/generate-worker.js
+++ b/www/generate-worker.js
@@ -1,0 +1,43 @@
+// Web Worker for G-code generation.
+// Runs WASM off the main thread so the UI stays responsive and can
+// display a live progress counter.
+
+import init, {
+  process_stl_progress, process_svg_progress,
+} from './pkg/rustcam.js';
+
+let wasmReady = false;
+
+async function boot() {
+  await init();
+  wasmReady = true;
+  self.postMessage({ type: 'ready' });
+}
+
+boot().catch(e => {
+  self.postMessage({ type: 'error', error: 'Worker WASM init failed: ' + e });
+});
+
+self.onmessage = (evt) => {
+  const { fileData, fileType, configJson } = evt.data;
+  if (!wasmReady) {
+    self.postMessage({ type: 'error', error: 'WASM not ready' });
+    return;
+  }
+
+  const onProgress = (completed, total) => {
+    self.postMessage({ type: 'progress', completed, total });
+  };
+
+  try {
+    let gcode;
+    if (fileType === 'stl') {
+      gcode = process_stl_progress(fileData, configJson, onProgress);
+    } else {
+      gcode = process_svg_progress(fileData, configJson, onProgress);
+    }
+    self.postMessage({ type: 'done', gcode });
+  } catch (e) {
+    self.postMessage({ type: 'error', error: String(e) });
+  }
+};

--- a/www/index.html
+++ b/www/index.html
@@ -532,24 +532,79 @@ function drawPreview(paths) {
 
 window.addEventListener('resize', () => { tryPreview(); resizeSim(); });
 
-// ── Generate ─────────────────────────────────────────────────────────
+// ── Generate (via Web Worker for progress reporting) ─────────────────
+let genWorker = null;
+let genStartTime = 0;
+
+function initWorker() {
+  genWorker = new Worker('./generate-worker.js', { type: 'module' });
+  genWorker.onmessage = (evt) => {
+    const msg = evt.data;
+    if (msg.type === 'ready') {
+      // Worker WASM loaded — nothing to do, main WASM already controls the button
+    } else if (msg.type === 'progress') {
+      const elapsed = ((performance.now() - genStartTime) / 1000).toFixed(1);
+      statusEl.textContent = `Generating... layer ${msg.completed} / ${msg.total}  (${elapsed}s)`;
+      statusEl.className = 'status';
+    } else if (msg.type === 'done') {
+      gcodeOut.value = msg.gcode;
+      const elapsed = ((performance.now() - genStartTime) / 1000).toFixed(1);
+      statusEl.textContent = `Done — ${msg.gcode.split('\n').length} lines of G-code in ${elapsed}s.`;
+      statusEl.className = 'status ok';
+      generateBtn.disabled = false;
+      tryPreview();
+      loadSim();
+    } else if (msg.type === 'error') {
+      statusEl.textContent = 'Error: ' + msg.error;
+      statusEl.className = 'status error';
+      generateBtn.disabled = false;
+    }
+  };
+  genWorker.onerror = (e) => {
+    statusEl.textContent = 'Worker error: ' + e.message;
+    statusEl.className = 'status error';
+    generateBtn.disabled = false;
+  };
+}
+
+// Try to start the worker; if module workers aren't supported, fall back
+// to running generation on the main thread (old behaviour).
+let workerSupported = true;
+try {
+  initWorker();
+} catch(e) {
+  workerSupported = false;
+  console.warn('Module workers not supported, using main-thread generation:', e);
+}
+
 generateBtn.addEventListener('click', () => {
   if (!wasmReady || !fileData) return;
-  statusEl.textContent = 'Generating...';
+  generateBtn.disabled = true;
+  statusEl.textContent = 'Generating... layer 0 / ?';
   statusEl.className = 'status';
-  try {
-    const cfg = getConfig();
-    let gcode;
-    if (fileType === 'stl') gcode = process_stl(fileData, cfg);
-    else gcode = process_svg(fileData, cfg);
-    gcodeOut.value = gcode;
-    statusEl.textContent = `Done — ${gcode.split('\n').length} lines of G-code.`;
-    statusEl.className = 'status ok';
-    tryPreview();
-    loadSim();
-  } catch(e) {
-    statusEl.textContent = 'Error: ' + e;
-    statusEl.className = 'status error';
+  genStartTime = performance.now();
+
+  const cfg = getConfig();
+
+  if (workerSupported && genWorker) {
+    genWorker.postMessage({ fileData, fileType, configJson: cfg });
+  } else {
+    // Fallback: run synchronously on main thread
+    try {
+      let gcode;
+      if (fileType === 'stl') gcode = process_stl(fileData, cfg);
+      else gcode = process_svg(fileData, cfg);
+      gcodeOut.value = gcode;
+      const elapsed = ((performance.now() - genStartTime) / 1000).toFixed(1);
+      statusEl.textContent = `Done — ${gcode.split('\n').length} lines of G-code in ${elapsed}s.`;
+      statusEl.className = 'status ok';
+      tryPreview();
+      loadSim();
+    } catch(e) {
+      statusEl.textContent = 'Error: ' + e;
+      statusEl.className = 'status error';
+    }
+    generateBtn.disabled = false;
   }
 });
 


### PR DESCRIPTION
Move G-code generation off the main thread into a Web Worker so the UI stays responsive during long operations. The Rust WASM code now reports progress after each layer via a JS callback, and the frontend displays a live "layer N / M" counter with elapsed time so you can tell whether generation is still running or frozen.

- Add js-sys dependency and process_stl_progress / process_svg_progress entry points that accept a progress callback
- Create www/generate-worker.js to run WASM in a module worker
- Update frontend generate button to use the worker with live status
- Graceful fallback to synchronous main-thread generation if module workers are not supported

https://claude.ai/code/session_01MrU8uY6HrXqBVg8vD2VHPe