### PR TITLE
feat: add machine profile system with CNC mill and laser cutter support

### DIFF
--- a/src/gcode.rs
+++ b/src/gcode.rs
@@ -3,7 +3,9 @@
 /// Swiss-cheese layer: **Output format**
 /// Extension point: implement alternative output formats (HPGL, DXF toolpath,
 /// Marlin flavour, GRBL flavour, etc.) by consuming `Vec<Toolpath>`.
+use crate::gcode_parser::{parse_line, validate_command, ParseError, ValidationConfig};
 use crate::geometry::Toolpath;
+use crate::machine::{MachineProfile, MachineType};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -75,6 +77,200 @@ pub fn emit_gcode(toolpaths: &[Toolpath], params: &GcodeParams) -> String {
     out
 }
 
+/// Extended params for profile-aware emission.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LaserParams {
+    pub power: f64,
+    pub passes: u32,
+}
+
+impl Default for LaserParams {
+    fn default() -> Self {
+        Self {
+            power: 100.0,
+            passes: 1,
+        }
+    }
+}
+
+/// Emit G-code using a machine profile for CNC/laser-specific output.
+pub fn emit_gcode_with_profile(
+    toolpaths: &[Toolpath],
+    params: &GcodeParams,
+    profile: &MachineProfile,
+    laser_params: Option<&LaserParams>,
+) -> String {
+    match profile.machine_type {
+        MachineType::CncMill => emit_gcode_cnc(toolpaths, params, profile),
+        MachineType::LaserCutter => emit_gcode_laser(
+            toolpaths,
+            params,
+            profile,
+            laser_params.unwrap_or(&LaserParams::default()),
+        ),
+    }
+}
+
+fn emit_gcode_cnc(
+    toolpaths: &[Toolpath],
+    params: &GcodeParams,
+    profile: &MachineProfile,
+) -> String {
+    let mut out = String::with_capacity(4096);
+
+    out.push_str("(RustCAM — generated G-code)\n");
+    for line in &profile.output_config.preamble {
+        out.push_str(line);
+        out.push('\n');
+    }
+    out.push_str(&format!("G0 Z{:.3}\n", params.safe_z));
+    out.push_str(&format!("M3 S{:.0} (spindle on)\n", params.spindle_speed));
+    out.push('\n');
+
+    for (idx, tp) in toolpaths.iter().enumerate() {
+        out.push_str(&format!("(Toolpath {})\n", idx + 1));
+        let mut last_rapid = true;
+
+        for mv in &tp.moves {
+            if mv.rapid {
+                out.push_str(&format!("G0 X{:.4} Y{:.4} Z{:.4}\n", mv.x, mv.y, mv.z));
+                last_rapid = true;
+            } else {
+                let feed = if mv.z < params.safe_z - 0.01 && last_rapid {
+                    params.plunge_rate
+                } else {
+                    params.feed_rate
+                };
+                out.push_str(&format!(
+                    "G1 X{:.4} Y{:.4} Z{:.4} F{:.0}\n",
+                    mv.x, mv.y, mv.z, feed
+                ));
+                last_rapid = false;
+            }
+        }
+        out.push('\n');
+    }
+
+    out.push_str(&format!("G0 Z{:.3}\n", params.safe_z));
+    for line in &profile.output_config.postamble {
+        out.push_str(line);
+        out.push('\n');
+    }
+
+    out
+}
+
+fn emit_gcode_laser(
+    toolpaths: &[Toolpath],
+    params: &GcodeParams,
+    profile: &MachineProfile,
+    laser_params: &LaserParams,
+) -> String {
+    let mut out = String::with_capacity(4096);
+
+    out.push_str("(RustCAM — generated G-code)\n");
+    for line in &profile.output_config.preamble {
+        out.push_str(line);
+        out.push('\n');
+    }
+    out.push('\n');
+
+    for pass in 0..laser_params.passes {
+        if laser_params.passes > 1 {
+            out.push_str(&format!("(Pass {} of {})\n", pass + 1, laser_params.passes));
+        }
+
+        for (idx, tp) in toolpaths.iter().enumerate() {
+            out.push_str(&format!("(Toolpath {})\n", idx + 1));
+
+            for mv in &tp.moves {
+                if mv.rapid {
+                    // Laser off during rapids
+                    out.push_str(&format!("G0 X{:.4} Y{:.4} S0\n", mv.x, mv.y));
+                } else {
+                    // Use move-specific power if available, otherwise default
+                    let power = mv.power.unwrap_or(laser_params.power);
+                    out.push_str(&format!(
+                        "G1 X{:.4} Y{:.4} F{:.0} S{:.0}\n",
+                        mv.x, mv.y, params.feed_rate, power
+                    ));
+                }
+            }
+            out.push('\n');
+        }
+    }
+
+    for line in &profile.output_config.postamble {
+        out.push_str(line);
+        out.push('\n');
+    }
+
+    out
+}
+
+/// A warning produced during G-code validation.
+#[derive(Debug, Clone)]
+pub struct GcodeWarning {
+    pub line_number: usize,
+    pub message: String,
+}
+
+/// Validate generated G-code by parsing and validating each line.
+/// Returns any warnings found alongside the original G-code.
+pub fn validate_gcode(gcode: &str, profile: &MachineProfile) -> Vec<GcodeWarning> {
+    let mut warnings = Vec::new();
+
+    let config = ValidationConfig {
+        max_feed_rate: profile.capabilities.max_feed_rate,
+        max_spindle_speed: profile.capabilities.max_spindle_rpm.unwrap_or(30000.0) as u32,
+        ..Default::default()
+    };
+
+    for (i, line) in gcode.lines().enumerate() {
+        let line_num = i + 1;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        match parse_line(trimmed) {
+            Ok(cmd) => {
+                if let Err(e) = validate_command(&cmd, &config) {
+                    warnings.push(GcodeWarning {
+                        line_number: line_num,
+                        message: e.to_string(),
+                    });
+                }
+
+                // Profile-specific checks: Z movement in laser mode
+                if profile.machine_type == MachineType::LaserCutter && cmd.is_motion() {
+                    if let crate::gcode_parser::GCodeCommand::RapidMove { z: Some(z), .. }
+                    | crate::gcode_parser::GCodeCommand::LinearMove { z: Some(z), .. } = &cmd
+                    {
+                        if z.abs() > 0.001 {
+                            warnings.push(GcodeWarning {
+                                line_number: line_num,
+                                message: format!(
+                                    "Z movement ({z:.3}) in laser mode - laser has no Z axis"
+                                ),
+                            });
+                        }
+                    }
+                }
+            }
+            Err(ParseError::EmptyLine) => {}
+            Err(e) => {
+                warnings.push(GcodeWarning {
+                    line_number: line_num,
+                    message: format!("Parse error: {e}"),
+                });
+            }
+        }
+    }
+
+    warnings
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -97,5 +293,113 @@ mod tests {
         let code = emit_gcode(&[tp], &GcodeParams::default());
         assert!(code.contains("G0 X10.0000 Y20.0000 Z5.0000"));
         assert!(code.contains("G1 X30.0000 Y20.0000 Z-1.0000"));
+    }
+
+    #[test]
+    fn test_cnc_profile_emitter() {
+        let profile = MachineProfile::cnc_mill();
+        let mut tp = Toolpath::new();
+        tp.rapid(10.0, 0.0, 5.0);
+        tp.cut(10.0, 0.0, -1.0);
+        let code = emit_gcode_with_profile(&[tp], &GcodeParams::default(), &profile, None);
+        assert!(code.contains("M3 S12000"));
+        assert!(code.contains("M5 (spindle off)"));
+        assert!(code.contains("M2 (program end)"));
+    }
+
+    #[test]
+    fn test_laser_profile_emitter() {
+        let profile = MachineProfile::laser_cutter();
+        let mut tp = Toolpath::new();
+        tp.rapid(10.0, 0.0, 0.0);
+        tp.cut(20.0, 0.0, 0.0);
+        let laser = LaserParams {
+            power: 80.0,
+            passes: 1,
+        };
+        let code = emit_gcode_with_profile(&[tp], &GcodeParams::default(), &profile, Some(&laser));
+        assert!(code.contains("M4 S0"), "Should have dynamic laser mode");
+        assert!(code.contains("S0\n"), "Rapids should have S0");
+        assert!(code.contains("S80"), "Cuts should have power");
+        assert!(!code.contains("Z"), "Laser should not have Z moves");
+    }
+
+    #[test]
+    fn test_laser_multi_pass() {
+        let profile = MachineProfile::laser_cutter();
+        let mut tp = Toolpath::new();
+        tp.cut(10.0, 0.0, 0.0);
+        let laser = LaserParams {
+            power: 50.0,
+            passes: 3,
+        };
+        let code = emit_gcode_with_profile(&[tp], &GcodeParams::default(), &profile, Some(&laser));
+        assert!(code.contains("Pass 1 of 3"));
+        assert!(code.contains("Pass 3 of 3"));
+    }
+
+    #[test]
+    fn test_laser_move_power() {
+        let profile = MachineProfile::laser_cutter();
+        let mut tp = Toolpath::new();
+        tp.cut_with_power(10.0, 0.0, 0.0, 42.0);
+        let laser = LaserParams {
+            power: 80.0,
+            passes: 1,
+        };
+        let code = emit_gcode_with_profile(&[tp], &GcodeParams::default(), &profile, Some(&laser));
+        assert!(
+            code.contains("S42"),
+            "Should use move-specific power, not default"
+        );
+    }
+
+    // ── Validation tests ──────────────────────────────────────────────
+
+    #[test]
+    fn test_validate_cnc_gcode_clean() {
+        let profile = MachineProfile::cnc_mill();
+        let mut tp = Toolpath::new();
+        tp.rapid(10.0, 0.0, 5.0);
+        tp.cut(10.0, 0.0, -1.0);
+        let code = emit_gcode_with_profile(&[tp], &GcodeParams::default(), &profile, None);
+        let warnings = validate_gcode(&code, &profile);
+        assert!(
+            warnings.is_empty(),
+            "Clean CNC G-code should have no warnings: {:?}",
+            warnings.iter().map(|w| &w.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_validate_laser_gcode_clean() {
+        let profile = MachineProfile::laser_cutter();
+        let mut tp = Toolpath::new();
+        tp.rapid(10.0, 0.0, 0.0);
+        tp.cut(20.0, 0.0, 0.0);
+        let laser = LaserParams {
+            power: 80.0,
+            passes: 1,
+        };
+        let code = emit_gcode_with_profile(&[tp], &GcodeParams::default(), &profile, Some(&laser));
+        let warnings = validate_gcode(&code, &profile);
+        assert!(
+            warnings.is_empty(),
+            "Clean laser G-code should have no warnings: {:?}",
+            warnings.iter().map(|w| &w.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_validate_detects_z_in_laser_mode() {
+        let profile = MachineProfile::laser_cutter();
+        // Manually crafted G-code with Z movement
+        let gcode = "G21\nG90\nG0 X10 Y0 Z5\nG1 X20 Y0 Z-1 F800\nM2\n";
+        let warnings = validate_gcode(gcode, &profile);
+        let z_warnings: Vec<_> = warnings
+            .iter()
+            .filter(|w| w.message.contains("Z movement"))
+            .collect();
+        assert!(!z_warnings.is_empty(), "Should warn about Z in laser mode");
     }
 }

--- a/src/gcode_parser.rs
+++ b/src/gcode_parser.rs
@@ -1,0 +1,747 @@
+//! G-code parser and validator.
+//!
+//! Ported from cnc-sender (cnc-types + cnc-gcode crates), combined into a
+//! single module for simplicity. Strips types we don't need for webCAM
+//! (MachinePosition, WorkPosition, Axis, Direction).
+
+use crate::units::SpindleSpeed;
+
+// ── Command types ────────────────────────────────────────────────────
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum MotionMode {
+    #[default]
+    Rapid = 0,
+    Linear = 1,
+    ClockwiseArc = 2,
+    CounterClockwiseArc = 3,
+}
+
+impl MotionMode {
+    #[must_use]
+    pub const fn gcode_number(self) -> u8 {
+        match self {
+            Self::Rapid => 0,
+            Self::Linear => 1,
+            Self::ClockwiseArc => 2,
+            Self::CounterClockwiseArc => 3,
+        }
+    }
+}
+
+impl std::fmt::Display for MotionMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "G{:02}", self.gcode_number())
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum DistanceMode {
+    #[default]
+    Absolute = 0,
+    Incremental = 1,
+}
+
+impl DistanceMode {
+    #[must_use]
+    pub const fn gcode_number(self) -> u8 {
+        match self {
+            Self::Absolute => 90,
+            Self::Incremental => 91,
+        }
+    }
+}
+
+impl std::fmt::Display for DistanceMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "G{}", self.gcode_number())
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum UnitMode {
+    Inches = 0,
+    #[default]
+    Millimeters = 1,
+}
+
+impl UnitMode {
+    #[must_use]
+    pub const fn gcode_number(self) -> u8 {
+        match self {
+            Self::Inches => 20,
+            Self::Millimeters => 21,
+        }
+    }
+}
+
+impl std::fmt::Display for UnitMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "G{}", self.gcode_number())
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub enum SpindleControl {
+    #[default]
+    Off,
+    Clockwise(SpindleSpeed),
+    CounterClockwise(SpindleSpeed),
+}
+
+impl SpindleControl {
+    #[must_use]
+    pub const fn is_running(&self) -> bool {
+        !matches!(self, Self::Off)
+    }
+
+    #[must_use]
+    pub const fn speed(&self) -> Option<SpindleSpeed> {
+        match self {
+            Self::Off => None,
+            Self::Clockwise(s) | Self::CounterClockwise(s) => Some(*s),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum CoolantControl {
+    #[default]
+    Off = 0,
+    Mist = 1,
+    Flood = 2,
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct AxisMask {
+    pub x: bool,
+    pub y: bool,
+    pub z: bool,
+}
+
+impl AxisMask {
+    pub const ALL: Self = Self {
+        x: true,
+        y: true,
+        z: true,
+    };
+
+    #[must_use]
+    pub const fn any(&self) -> bool {
+        self.x || self.y || self.z
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum WorkOffset {
+    #[default]
+    G54 = 0,
+    G55 = 1,
+    G56 = 2,
+    G57 = 3,
+    G58 = 4,
+    G59 = 5,
+}
+
+impl WorkOffset {
+    #[must_use]
+    pub const fn gcode_number(self) -> u8 {
+        match self {
+            Self::G54 => 54,
+            Self::G55 => 55,
+            Self::G56 => 56,
+            Self::G57 => 57,
+            Self::G58 => 58,
+            Self::G59 => 59,
+        }
+    }
+
+    #[must_use]
+    pub const fn from_gcode(code: u8) -> Option<Self> {
+        match code {
+            54 => Some(Self::G54),
+            55 => Some(Self::G55),
+            56 => Some(Self::G56),
+            57 => Some(Self::G57),
+            58 => Some(Self::G58),
+            59 => Some(Self::G59),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for WorkOffset {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "G{}", self.gcode_number())
+    }
+}
+
+/// A parsed G-code command.
+#[derive(Clone, Debug, PartialEq)]
+pub enum GCodeCommand {
+    RapidMove {
+        x: Option<f64>,
+        y: Option<f64>,
+        z: Option<f64>,
+    },
+    LinearMove {
+        x: Option<f64>,
+        y: Option<f64>,
+        z: Option<f64>,
+        feed: Option<f64>,
+    },
+    ArcMove {
+        clockwise: bool,
+        x: Option<f64>,
+        y: Option<f64>,
+        i: Option<f64>,
+        j: Option<f64>,
+        feed: Option<f64>,
+    },
+    SetUnits(UnitMode),
+    SetDistanceMode(DistanceMode),
+    SetWorkOffset(WorkOffset),
+    SetSpindle(SpindleControl),
+    SetCoolant(CoolantControl),
+    Dwell {
+        seconds: f64,
+    },
+    ProgramEnd,
+    ProgramPause,
+    Home {
+        axes: AxisMask,
+    },
+    ProbeToward {
+        z: f64,
+        feed: f64,
+    },
+    Raw(String),
+    Comment(String),
+}
+
+impl GCodeCommand {
+    #[must_use]
+    pub const fn is_motion(&self) -> bool {
+        matches!(
+            self,
+            Self::RapidMove { .. } | Self::LinearMove { .. } | Self::ArcMove { .. }
+        )
+    }
+
+    #[must_use]
+    pub const fn is_modal(&self) -> bool {
+        matches!(
+            self,
+            Self::SetUnits(_)
+                | Self::SetDistanceMode(_)
+                | Self::SetWorkOffset(_)
+                | Self::SetSpindle(_)
+                | Self::SetCoolant(_)
+        )
+    }
+
+    #[must_use]
+    pub const fn motion_mode(&self) -> Option<MotionMode> {
+        match self {
+            Self::RapidMove { .. } => Some(MotionMode::Rapid),
+            Self::LinearMove { .. } => Some(MotionMode::Linear),
+            Self::ArcMove {
+                clockwise: true, ..
+            } => Some(MotionMode::ClockwiseArc),
+            Self::ArcMove {
+                clockwise: false, ..
+            } => Some(MotionMode::CounterClockwiseArc),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for GCodeCommand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RapidMove { x, y, z } => {
+                write!(f, "G00")?;
+                if let Some(v) = x {
+                    write!(f, " X{v:.4}")?;
+                }
+                if let Some(v) = y {
+                    write!(f, " Y{v:.4}")?;
+                }
+                if let Some(v) = z {
+                    write!(f, " Z{v:.4}")?;
+                }
+                Ok(())
+            }
+            Self::LinearMove { x, y, z, feed } => {
+                write!(f, "G01")?;
+                if let Some(v) = x {
+                    write!(f, " X{v:.4}")?;
+                }
+                if let Some(v) = y {
+                    write!(f, " Y{v:.4}")?;
+                }
+                if let Some(v) = z {
+                    write!(f, " Z{v:.4}")?;
+                }
+                if let Some(v) = feed {
+                    write!(f, " F{v:.0}")?;
+                }
+                Ok(())
+            }
+            Self::ArcMove {
+                clockwise,
+                x,
+                y,
+                i,
+                j,
+                feed,
+            } => {
+                write!(f, "{}", if *clockwise { "G02" } else { "G03" })?;
+                if let Some(v) = x {
+                    write!(f, " X{v:.4}")?;
+                }
+                if let Some(v) = y {
+                    write!(f, " Y{v:.4}")?;
+                }
+                if let Some(v) = i {
+                    write!(f, " I{v:.4}")?;
+                }
+                if let Some(v) = j {
+                    write!(f, " J{v:.4}")?;
+                }
+                if let Some(v) = feed {
+                    write!(f, " F{v:.0}")?;
+                }
+                Ok(())
+            }
+            Self::SetUnits(mode) => write!(f, "{mode}"),
+            Self::SetDistanceMode(mode) => write!(f, "{mode}"),
+            Self::SetWorkOffset(offset) => write!(f, "{offset}"),
+            Self::SetSpindle(ctrl) => match ctrl {
+                SpindleControl::Off => write!(f, "M05"),
+                SpindleControl::Clockwise(s) => write!(f, "M03 S{}", s.rpm()),
+                SpindleControl::CounterClockwise(s) => write!(f, "M04 S{}", s.rpm()),
+            },
+            Self::SetCoolant(ctrl) => match ctrl {
+                CoolantControl::Off => write!(f, "M09"),
+                CoolantControl::Mist => write!(f, "M07"),
+                CoolantControl::Flood => write!(f, "M08"),
+            },
+            Self::Dwell { seconds } => write!(f, "G04 P{seconds:.3}"),
+            Self::ProgramEnd => write!(f, "M02"),
+            Self::ProgramPause => write!(f, "M00"),
+            Self::Home { axes } => {
+                write!(f, "G28")?;
+                if axes.x {
+                    write!(f, " X0")?;
+                }
+                if axes.y {
+                    write!(f, " Y0")?;
+                }
+                if axes.z {
+                    write!(f, " Z0")?;
+                }
+                Ok(())
+            }
+            Self::ProbeToward { z, feed } => write!(f, "G38.2 Z{z:.4} F{feed:.0}"),
+            Self::Raw(s) => write!(f, "{s}"),
+            Self::Comment(s) => write!(f, "({s})"),
+        }
+    }
+}
+
+// ── Parser ───────────────────────────────────────────────────────────
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ParseError {
+    InvalidNumber(String),
+    UnknownGCode(u8),
+    UnknownMCode(u8),
+    MissingParameter(char),
+    EmptyLine,
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidNumber(s) => write!(f, "Invalid number: {s}"),
+            Self::UnknownGCode(n) => write!(f, "Unknown G-code: G{n}"),
+            Self::UnknownMCode(n) => write!(f, "Unknown M-code: M{n}"),
+            Self::MissingParameter(c) => write!(f, "Missing parameter: {c}"),
+            Self::EmptyLine => write!(f, "Empty line"),
+        }
+    }
+}
+
+/// Parses a single G-code line into a command.
+pub fn parse_line(line: &str) -> Result<GCodeCommand, ParseError> {
+    let line = strip_comments(line);
+    let line = line.trim().to_uppercase();
+
+    if line.is_empty() {
+        return Err(ParseError::EmptyLine);
+    }
+
+    if line.starts_with('(') || line.starts_with(';') {
+        return Ok(GCodeCommand::Comment(line));
+    }
+
+    let words = parse_words(&line)?;
+
+    let g_code = words.iter().find(|(c, _)| *c == 'G');
+    let m_code = words.iter().find(|(c, _)| *c == 'M');
+
+    match (g_code, m_code) {
+        (Some(&(_, g)), _) => parse_g_code(g as u8, &words),
+        (None, Some(&(_, m))) => parse_m_code(m as u8, &words),
+        (None, None) => {
+            if words.iter().any(|(c, _)| matches!(c, 'X' | 'Y' | 'Z')) {
+                parse_g_code(1, &words)
+            } else {
+                Ok(GCodeCommand::Raw(line))
+            }
+        }
+    }
+}
+
+fn strip_comments(line: &str) -> &str {
+    let line = line.split(';').next().unwrap_or(line);
+    if let Some(paren_start) = line.find('(') {
+        if let Some(paren_end) = line.find(')') {
+            let before = &line[..paren_start];
+            let after = &line[paren_end + 1..];
+            if !before.trim().is_empty() {
+                return before;
+            }
+            if !after.trim().is_empty() {
+                return after;
+            }
+        }
+    }
+    line
+}
+
+fn parse_words(line: &str) -> Result<Vec<(char, f64)>, ParseError> {
+    let mut words = Vec::new();
+    let mut chars = line.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c.is_whitespace() {
+            continue;
+        }
+
+        if c.is_ascii_alphabetic() {
+            let letter = c;
+            let mut num_str = String::new();
+
+            if chars.peek() == Some(&'-') {
+                num_str.push(chars.next().unwrap());
+            }
+
+            while let Some(&ch) = chars.peek() {
+                if ch.is_ascii_digit() || ch == '.' {
+                    num_str.push(chars.next().unwrap());
+                } else {
+                    break;
+                }
+            }
+
+            if num_str.is_empty() {
+                words.push((letter, 0.0));
+            } else {
+                let value: f64 = num_str
+                    .parse()
+                    .map_err(|_| ParseError::InvalidNumber(num_str))?;
+                words.push((letter, value));
+            }
+        }
+    }
+
+    Ok(words)
+}
+
+fn parse_g_code(code: u8, words: &[(char, f64)]) -> Result<GCodeCommand, ParseError> {
+    let get_word =
+        |letter: char| -> Option<f64> { words.iter().find(|(c, _)| *c == letter).map(|(_, v)| *v) };
+
+    match code {
+        0 => Ok(GCodeCommand::RapidMove {
+            x: get_word('X'),
+            y: get_word('Y'),
+            z: get_word('Z'),
+        }),
+        1 => Ok(GCodeCommand::LinearMove {
+            x: get_word('X'),
+            y: get_word('Y'),
+            z: get_word('Z'),
+            feed: get_word('F'),
+        }),
+        2 => Ok(GCodeCommand::ArcMove {
+            clockwise: true,
+            x: get_word('X'),
+            y: get_word('Y'),
+            i: get_word('I'),
+            j: get_word('J'),
+            feed: get_word('F'),
+        }),
+        3 => Ok(GCodeCommand::ArcMove {
+            clockwise: false,
+            x: get_word('X'),
+            y: get_word('Y'),
+            i: get_word('I'),
+            j: get_word('J'),
+            feed: get_word('F'),
+        }),
+        4 => {
+            let seconds = get_word('P').unwrap_or(0.0);
+            Ok(GCodeCommand::Dwell { seconds })
+        }
+        20 => Ok(GCodeCommand::SetUnits(UnitMode::Inches)),
+        21 => Ok(GCodeCommand::SetUnits(UnitMode::Millimeters)),
+        28 => {
+            let axes = AxisMask {
+                x: get_word('X').is_some(),
+                y: get_word('Y').is_some(),
+                z: get_word('Z').is_some(),
+            };
+            Ok(GCodeCommand::Home { axes })
+        }
+        38 => {
+            let z = get_word('Z').ok_or(ParseError::MissingParameter('Z'))?;
+            let feed = get_word('F').ok_or(ParseError::MissingParameter('F'))?;
+            Ok(GCodeCommand::ProbeToward { z, feed })
+        }
+        54 => Ok(GCodeCommand::SetWorkOffset(WorkOffset::G54)),
+        55 => Ok(GCodeCommand::SetWorkOffset(WorkOffset::G55)),
+        56 => Ok(GCodeCommand::SetWorkOffset(WorkOffset::G56)),
+        57 => Ok(GCodeCommand::SetWorkOffset(WorkOffset::G57)),
+        58 => Ok(GCodeCommand::SetWorkOffset(WorkOffset::G58)),
+        59 => Ok(GCodeCommand::SetWorkOffset(WorkOffset::G59)),
+        90 => Ok(GCodeCommand::SetDistanceMode(DistanceMode::Absolute)),
+        91 => Ok(GCodeCommand::SetDistanceMode(DistanceMode::Incremental)),
+        _ => Err(ParseError::UnknownGCode(code)),
+    }
+}
+
+fn parse_m_code(code: u8, words: &[(char, f64)]) -> Result<GCodeCommand, ParseError> {
+    let get_word =
+        |letter: char| -> Option<f64> { words.iter().find(|(c, _)| *c == letter).map(|(_, v)| *v) };
+
+    match code {
+        0 => Ok(GCodeCommand::ProgramPause),
+        2 | 30 => Ok(GCodeCommand::ProgramEnd),
+        3 => {
+            let speed = get_word('S').map(|s| s as u32).unwrap_or(0);
+            Ok(GCodeCommand::SetSpindle(SpindleControl::Clockwise(
+                SpindleSpeed::new(speed),
+            )))
+        }
+        4 => {
+            let speed = get_word('S').map(|s| s as u32).unwrap_or(0);
+            Ok(GCodeCommand::SetSpindle(SpindleControl::CounterClockwise(
+                SpindleSpeed::new(speed),
+            )))
+        }
+        5 => Ok(GCodeCommand::SetSpindle(SpindleControl::Off)),
+        7 => Ok(GCodeCommand::SetCoolant(CoolantControl::Mist)),
+        8 => Ok(GCodeCommand::SetCoolant(CoolantControl::Flood)),
+        9 => Ok(GCodeCommand::SetCoolant(CoolantControl::Off)),
+        _ => Err(ParseError::UnknownMCode(code)),
+    }
+}
+
+// ── Validator ────────────────────────────────────────────────────────
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ValidationError {
+    InvalidFeedRate(f64),
+    InvalidDwellTime(f64),
+    InvalidArcRadius,
+    NoAxisSpecified,
+    SpindleSpeedOutOfRange(u32),
+}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidFeedRate(v) => write!(f, "Invalid feed rate: {v}"),
+            Self::InvalidDwellTime(v) => write!(f, "Invalid dwell time: {v}"),
+            Self::InvalidArcRadius => write!(f, "Invalid arc radius"),
+            Self::NoAxisSpecified => write!(f, "No axis specified"),
+            Self::SpindleSpeedOutOfRange(v) => write!(f, "Spindle speed out of range: {v}"),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidationConfig {
+    pub max_feed_rate: f64,
+    pub max_spindle_speed: u32,
+    pub max_travel: [f64; 3],
+}
+
+impl Default for ValidationConfig {
+    fn default() -> Self {
+        Self {
+            max_feed_rate: 10000.0,
+            max_spindle_speed: 30000,
+            max_travel: [300.0, 300.0, 100.0],
+        }
+    }
+}
+
+pub fn validate_command(
+    cmd: &GCodeCommand,
+    config: &ValidationConfig,
+) -> Result<(), ValidationError> {
+    match cmd {
+        GCodeCommand::LinearMove { feed, .. } | GCodeCommand::ArcMove { feed, .. } => {
+            if let Some(f) = feed {
+                if *f <= 0.0 || *f > config.max_feed_rate {
+                    return Err(ValidationError::InvalidFeedRate(*f));
+                }
+            }
+        }
+        GCodeCommand::Dwell { seconds } => {
+            if *seconds < 0.0 {
+                return Err(ValidationError::InvalidDwellTime(*seconds));
+            }
+        }
+        GCodeCommand::SetSpindle(ctrl) => {
+            if let Some(speed) = ctrl.speed() {
+                if speed.rpm() > config.max_spindle_speed {
+                    return Err(ValidationError::SpindleSpeedOutOfRange(speed.rpm()));
+                }
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_rapid_move() {
+        let cmd = parse_line("G00 X10.5 Y20.0 Z-5.0").unwrap();
+        match cmd {
+            GCodeCommand::RapidMove { x, y, z } => {
+                assert_eq!(x, Some(10.5));
+                assert_eq!(y, Some(20.0));
+                assert_eq!(z, Some(-5.0));
+            }
+            _ => panic!("Expected RapidMove"),
+        }
+    }
+
+    #[test]
+    fn parse_linear_move() {
+        let cmd = parse_line("G01 X10 F1000").unwrap();
+        match cmd {
+            GCodeCommand::LinearMove { x, y, z, feed } => {
+                assert_eq!(x, Some(10.0));
+                assert_eq!(y, None);
+                assert_eq!(z, None);
+                assert_eq!(feed, Some(1000.0));
+            }
+            _ => panic!("Expected LinearMove"),
+        }
+    }
+
+    #[test]
+    fn parse_spindle_on() {
+        let cmd = parse_line("M03 S2000").unwrap();
+        match cmd {
+            GCodeCommand::SetSpindle(SpindleControl::Clockwise(speed)) => {
+                assert_eq!(speed.rpm(), 2000);
+            }
+            _ => panic!("Expected SetSpindle Clockwise"),
+        }
+    }
+
+    #[test]
+    fn strip_comment() {
+        let cmd = parse_line("G00 X10 ; move to X").unwrap();
+        assert!(matches!(cmd, GCodeCommand::RapidMove { .. }));
+    }
+
+    #[test]
+    fn case_insensitive() {
+        let cmd1 = parse_line("g00 x10").unwrap();
+        let cmd2 = parse_line("G00 X10").unwrap();
+        assert_eq!(cmd1, cmd2);
+    }
+
+    #[test]
+    fn command_display() {
+        let cmd = GCodeCommand::LinearMove {
+            x: Some(10.0),
+            y: Some(20.0),
+            z: None,
+            feed: Some(1000.0),
+        };
+        assert_eq!(format!("{cmd}"), "G01 X10.0000 Y20.0000 F1000");
+    }
+
+    #[test]
+    fn validate_feed_rate() {
+        let config = ValidationConfig::default();
+        let valid = GCodeCommand::LinearMove {
+            x: Some(10.0),
+            y: None,
+            z: None,
+            feed: Some(1000.0),
+        };
+        assert!(validate_command(&valid, &config).is_ok());
+
+        let invalid = GCodeCommand::LinearMove {
+            x: Some(10.0),
+            y: None,
+            z: None,
+            feed: Some(-100.0),
+        };
+        assert!(matches!(
+            validate_command(&invalid, &config),
+            Err(ValidationError::InvalidFeedRate(_))
+        ));
+    }
+
+    #[test]
+    fn validate_spindle_speed() {
+        let config = ValidationConfig {
+            max_spindle_speed: 3000,
+            ..Default::default()
+        };
+        let valid = GCodeCommand::SetSpindle(SpindleControl::Clockwise(SpindleSpeed::new(2000)));
+        assert!(validate_command(&valid, &config).is_ok());
+
+        let invalid = GCodeCommand::SetSpindle(SpindleControl::Clockwise(SpindleSpeed::new(5000)));
+        assert!(matches!(
+            validate_command(&invalid, &config),
+            Err(ValidationError::SpindleSpeedOutOfRange(5000))
+        ));
+    }
+
+    #[test]
+    fn work_offset_roundtrip() {
+        for offset in [
+            WorkOffset::G54,
+            WorkOffset::G55,
+            WorkOffset::G56,
+            WorkOffset::G57,
+            WorkOffset::G58,
+            WorkOffset::G59,
+        ] {
+            let code = offset.gcode_number();
+            let parsed = WorkOffset::from_gcode(code);
+            assert_eq!(parsed, Some(offset));
+        }
+    }
+}

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -174,6 +174,10 @@ pub struct ToolpathMove {
     pub y: f64,
     pub z: f64,
     pub rapid: bool,
+    /// Laser power level (0-100). None means no change from current power.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub power: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -191,6 +195,7 @@ impl Toolpath {
             y,
             z,
             rapid: true,
+            power: None,
         });
     }
     pub fn cut(&mut self, x: f64, y: f64, z: f64) {
@@ -199,6 +204,17 @@ impl Toolpath {
             y,
             z,
             rapid: false,
+            power: None,
+        });
+    }
+    /// Add a cutting move with laser power metadata.
+    pub fn cut_with_power(&mut self, x: f64, y: f64, z: f64, power: f64) {
+        self.moves.push(ToolpathMove {
+            x,
+            y,
+            z,
+            rapid: false,
+            power: Some(power),
         });
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,23 +20,27 @@
 //! without touching existing code.
 
 pub mod gcode;
+pub mod gcode_parser;
 pub mod geometry;
+pub mod machine;
 pub mod slicer;
 pub mod stl;
 pub mod svg;
 pub mod tool;
 pub mod toolpath;
+pub mod units;
 
-use gcode::{emit_gcode, GcodeParams};
+use gcode::{emit_gcode, emit_gcode_with_profile, GcodeParams, LaserParams};
 use geometry::Toolpath;
+use js_sys::Function;
+use machine::{MachineProfile, MachineType};
 use serde::{Deserialize, Serialize};
 use tool::Tool;
 use toolpath::{
-    ContourStrategy, CutParams, PerimeterStrategy, PocketStrategy, ScanDirection, SurfaceParams,
-    ToolpathStrategy, ZigzagSurfaceStrategy,
+    ContourStrategy, CutParams, LaserCutStrategy, LaserEngraveStrategy, PerimeterStrategy,
+    PocketStrategy, ScanDirection, SurfaceParams, ToolpathStrategy, ZigzagSurfaceStrategy,
 };
 use wasm_bindgen::prelude::*;
-use js_sys::Function;
 
 // ── Public parameter struct (JSON from JS) ───────────────────────────
 
@@ -72,6 +76,14 @@ pub struct CamConfig {
     pub perimeter_passes: u32,
     #[serde(default = "default_scan_direction")]
     pub scan_direction: String,
+    #[serde(default = "default_machine_type")]
+    pub machine_type: String,
+    #[serde(default)]
+    pub laser_power: Option<f64>,
+    #[serde(default)]
+    pub passes: Option<u32>,
+    #[serde(default)]
+    pub air_assist: Option<bool>,
 }
 
 fn default_tool_diameter() -> f64 {
@@ -110,6 +122,9 @@ fn default_scan_direction() -> String {
 fn default_strategy() -> String {
     "contour".into()
 }
+fn default_machine_type() -> String {
+    "cnc_mill".into()
+}
 
 impl Default for CamConfig {
     fn default() -> Self {
@@ -129,6 +144,10 @@ impl Default for CamConfig {
             climb_cut: false,
             perimeter_passes: default_perimeter_passes(),
             scan_direction: default_scan_direction(),
+            machine_type: default_machine_type(),
+            laser_power: None,
+            passes: None,
+            air_assist: None,
         }
     }
 }
@@ -159,6 +178,69 @@ fn tool_from_config(config: &CamConfig) -> Tool {
     }
 }
 
+/// Resolve a MachineProfile from the config's machine_type field.
+fn profile_from_config(config: &CamConfig) -> MachineProfile {
+    match config.machine_type.as_str() {
+        "laser_cutter" => MachineProfile::laser_cutter(),
+        _ => MachineProfile::cnc_mill(),
+    }
+}
+
+/// Build LaserParams from config, if applicable.
+fn laser_params_from_config(config: &CamConfig) -> Option<LaserParams> {
+    if config.machine_type == "laser_cutter" {
+        Some(LaserParams {
+            power: config.laser_power.unwrap_or(100.0),
+            passes: config.passes.unwrap_or(1),
+        })
+    } else {
+        None
+    }
+}
+
+/// Select the right strategy based on config and profile.
+fn strategy_from_config(config: &CamConfig) -> Box<dyn ToolpathStrategy> {
+    match config.strategy.as_str() {
+        "pocket" => Box::new(PocketStrategy),
+        "perimeter" => Box::new(PerimeterStrategy),
+        "laser_cut" => Box::new(LaserCutStrategy::new(config.laser_power.unwrap_or(100.0))),
+        "laser_engrave" => Box::new(LaserEngraveStrategy::new(
+            config.laser_power.unwrap_or(100.0),
+            config.step_over,
+        )),
+        _ => Box::new(ContourStrategy),
+    }
+}
+
+// ── New WASM API ─────────────────────────────────────────────────────
+
+/// Return JSON list of available machine profiles.
+#[wasm_bindgen]
+pub fn available_profiles() -> String {
+    let profiles = vec![MachineProfile::cnc_mill(), MachineProfile::laser_cutter()];
+    serde_json::to_string(&profiles).unwrap_or_else(|_| "[]".into())
+}
+
+/// Return a default config JSON for the given machine type.
+#[wasm_bindgen]
+pub fn default_config(machine_type: &str) -> String {
+    let config = if machine_type == "laser_cutter" {
+        CamConfig {
+            machine_type: machine_type.into(),
+            strategy: "laser_cut".into(),
+            laser_power: Some(100.0),
+            passes: Some(1),
+            ..CamConfig::default()
+        }
+    } else {
+        CamConfig {
+            machine_type: machine_type.into(),
+            ..CamConfig::default()
+        }
+    };
+    serde_json::to_string(&config).unwrap_or_else(|_| "{}".into())
+}
+
 // ── WASM entry points ────────────────────────────────────────────────
 
 /// Process an STL file (binary bytes) and return G-code.
@@ -166,6 +248,11 @@ fn tool_from_config(config: &CamConfig) -> Tool {
 pub fn process_stl(data: &[u8], config_json: &str) -> Result<String, JsValue> {
     let config: CamConfig =
         serde_json::from_str(config_json).map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+    let profile = profile_from_config(&config);
+    profile
+        .validate_strategy(&config.strategy)
+        .map_err(|e| JsValue::from_str(&e))?;
 
     let mesh = stl::parse_stl(data).map_err(|e| JsValue::from_str(&e))?;
 
@@ -218,7 +305,8 @@ pub fn process_stl(data: &[u8], config_json: &str) -> Result<String, JsValue> {
         "zigzag" => {
             // 3D surface zigzag raster
             let strategy = ZigzagSurfaceStrategy;
-            let surface_params = SurfaceParams::new(&mesh, cut_params, scan_direction_from_config(&config));
+            let surface_params =
+                SurfaceParams::new(&mesh, cut_params, scan_direction_from_config(&config));
             strategy.generate_surface(&surface_params)
         }
         "perimeter" => {
@@ -253,7 +341,13 @@ pub fn process_stl(data: &[u8], config_json: &str) -> Result<String, JsValue> {
         }
     };
 
-    Ok(emit_gcode(&toolpaths, &gcode_params))
+    let laser = laser_params_from_config(&config);
+    Ok(emit_gcode_with_profile(
+        &toolpaths,
+        &gcode_params,
+        &profile,
+        laser.as_ref(),
+    ))
 }
 
 /// Process an SVG string and return G-code.
@@ -261,6 +355,11 @@ pub fn process_stl(data: &[u8], config_json: &str) -> Result<String, JsValue> {
 pub fn process_svg(svg_text: &str, config_json: &str) -> Result<String, JsValue> {
     let config: CamConfig =
         serde_json::from_str(config_json).map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+    let profile = profile_from_config(&config);
+    profile
+        .validate_strategy(&config.strategy)
+        .map_err(|e| JsValue::from_str(&e))?;
 
     let polylines = svg::parse_svg(svg_text).map_err(|e| JsValue::from_str(&e))?;
 
@@ -285,29 +384,38 @@ pub fn process_svg(svg_text: &str, config_json: &str) -> Result<String, JsValue>
         unit_mm: true,
     };
 
-    let strategy: Box<dyn ToolpathStrategy> = match config.strategy.as_str() {
-        "pocket" => Box::new(PocketStrategy),
-        "perimeter" => Box::new(PerimeterStrategy),
-        _ => Box::new(ContourStrategy),
-    };
+    let strategy = strategy_from_config(&config);
 
-    // For 2-D SVG, step down from 0 to cut_depth
+    // Laser strategies run single pass at Z=0
+    let is_laser = profile.machine_type == MachineType::LaserCutter;
     let mut all_toolpaths = Vec::new();
-    let mut z = 0.0;
-    while z > config.cut_depth - 0.001 {
-        z -= config.step_down;
-        if z < config.cut_depth {
-            z = config.cut_depth;
-        }
-        let mut p = cut_params.clone();
-        p.cut_z = z;
-        all_toolpaths.extend(strategy.generate(&polylines, &p));
-        if (z - config.cut_depth).abs() < 0.001 {
-            break;
+
+    if is_laser {
+        all_toolpaths.extend(strategy.generate(&polylines, &cut_params));
+    } else {
+        // For 2-D SVG, step down from 0 to cut_depth
+        let mut z = 0.0;
+        while z > config.cut_depth - 0.001 {
+            z -= config.step_down;
+            if z < config.cut_depth {
+                z = config.cut_depth;
+            }
+            let mut p = cut_params.clone();
+            p.cut_z = z;
+            all_toolpaths.extend(strategy.generate(&polylines, &p));
+            if (z - config.cut_depth).abs() < 0.001 {
+                break;
+            }
         }
     }
 
-    Ok(emit_gcode(&all_toolpaths, &gcode_params))
+    let laser = laser_params_from_config(&config);
+    Ok(emit_gcode_with_profile(
+        &all_toolpaths,
+        &gcode_params,
+        &profile,
+        laser.as_ref(),
+    ))
 }
 
 /// Helper: call a JS progress callback with (completed, total).
@@ -381,10 +489,8 @@ pub fn process_stl_progress(
                 report_progress(on_progress, (i + 1) as u32, total);
             }
             if all.is_empty() && other != "pocket" && other != "perimeter" {
-                let contours = slicer::slice_at_z(
-                    &mesh,
-                    mesh.bounds.as_ref().map_or(0.0, |b| b.min.z + 0.01),
-                );
+                let contours =
+                    slicer::slice_at_z(&mesh, mesh.bounds.as_ref().map_or(0.0, |b| b.min.z + 0.01));
                 all.extend(strategy.generate(&contours, &cut_params));
             }
             all
@@ -547,7 +653,8 @@ fn build_toolpaths_stl(mesh: &geometry::Mesh, config: &CamConfig) -> Vec<Toolpat
     // Handle zigzag separately (3D surface strategy)
     if config.strategy == "zigzag" {
         let strategy = ZigzagSurfaceStrategy;
-        let surface_params = SurfaceParams::new(mesh, cut_params, scan_direction_from_config(config));
+        let surface_params =
+            SurfaceParams::new(mesh, cut_params, scan_direction_from_config(config));
         return strategy.generate_surface(&surface_params);
     }
 
@@ -584,23 +691,25 @@ fn build_toolpaths_svg(polylines: &[geometry::Polyline], config: &CamConfig) -> 
         climb_cut: config.climb_cut,
         perimeter_passes: config.perimeter_passes,
     };
-    let strategy: Box<dyn ToolpathStrategy> = match config.strategy.as_str() {
-        "pocket" => Box::new(PocketStrategy),
-        "perimeter" => Box::new(PerimeterStrategy),
-        _ => Box::new(ContourStrategy),
-    };
+    let strategy = strategy_from_config(config);
+    let is_laser = config.machine_type == "laser_cutter";
+
     let mut all = Vec::new();
-    let mut z = 0.0;
-    while z > config.cut_depth - 0.001 {
-        z -= config.step_down;
-        if z < config.cut_depth {
-            z = config.cut_depth;
-        }
-        let mut p = cut_params.clone();
-        p.cut_z = z;
-        all.extend(strategy.generate(polylines, &p));
-        if (z - config.cut_depth).abs() < 0.001 {
-            break;
+    if is_laser {
+        all.extend(strategy.generate(polylines, &cut_params));
+    } else {
+        let mut z = 0.0;
+        while z > config.cut_depth - 0.001 {
+            z -= config.step_down;
+            if z < config.cut_depth {
+                z = config.cut_depth;
+            }
+            let mut p = cut_params.clone();
+            p.cut_z = z;
+            all.extend(strategy.generate(polylines, &p));
+            if (z - config.cut_depth).abs() < 0.001 {
+                break;
+            }
         }
     }
     all
@@ -682,5 +791,127 @@ mod tests {
         };
         let tool = tool_from_config(&config);
         assert!((tool.effective_diameter() - 40.0).abs() < 0.001);
+    }
+
+    // ── Machine profile integration tests ─────────────────────────────
+
+    #[test]
+    fn test_config_machine_type_default() {
+        let config = CamConfig::default();
+        assert_eq!(config.machine_type, "cnc_mill");
+    }
+
+    #[test]
+    fn test_config_parses_laser() {
+        let json = r#"{"machine_type": "laser_cutter", "laser_power": 80, "passes": 3}"#;
+        let config: CamConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.machine_type, "laser_cutter");
+        assert_eq!(config.laser_power, Some(80.0));
+        assert_eq!(config.passes, Some(3));
+    }
+
+    #[test]
+    fn test_profile_from_config_cnc() {
+        let config = CamConfig::default();
+        let profile = profile_from_config(&config);
+        assert_eq!(profile.machine_type, MachineType::CncMill);
+    }
+
+    #[test]
+    fn test_profile_from_config_laser() {
+        let config = CamConfig {
+            machine_type: "laser_cutter".into(),
+            ..CamConfig::default()
+        };
+        let profile = profile_from_config(&config);
+        assert_eq!(profile.machine_type, MachineType::LaserCutter);
+    }
+
+    #[test]
+    fn test_laser_rejects_stl_3d_strategy() {
+        let config = CamConfig {
+            machine_type: "laser_cutter".into(),
+            strategy: "zigzag".into(),
+            ..CamConfig::default()
+        };
+        let profile = profile_from_config(&config);
+        assert!(profile.validate_strategy(&config.strategy).is_err());
+    }
+
+    #[test]
+    fn test_laser_rejects_slice_strategy() {
+        let config = CamConfig {
+            machine_type: "laser_cutter".into(),
+            strategy: "slice".into(),
+            ..CamConfig::default()
+        };
+        let profile = profile_from_config(&config);
+        assert!(profile.validate_strategy(&config.strategy).is_err());
+    }
+
+    #[test]
+    fn test_svg_laser_cut_produces_gcode() {
+        let svg = r#"<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+            <rect x="10" y="10" width="80" height="80"/>
+        </svg>"#;
+        let config_json =
+            r#"{"machine_type": "laser_cutter", "strategy": "laser_cut", "laser_power": 80}"#;
+        let result = process_svg(svg, config_json);
+        assert!(result.is_ok());
+        let gcode = result.unwrap();
+        assert!(gcode.contains("M4 S0"), "Should have laser dynamic mode");
+        assert!(gcode.contains("S80"), "Should have power commands");
+        assert!(gcode.contains("M5"), "Should turn off laser at end");
+    }
+
+    #[test]
+    fn test_svg_laser_engrave_produces_scanlines() {
+        let svg = r#"<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+            <rect x="10" y="10" width="80" height="80"/>
+        </svg>"#;
+        let config_json = r#"{"machine_type": "laser_cutter", "strategy": "laser_engrave", "laser_power": 60, "step_over": 2.0}"#;
+        let result = process_svg(svg, config_json);
+        assert!(result.is_ok());
+        let gcode = result.unwrap();
+        assert!(gcode.contains("S60"), "Should have engrave power");
+    }
+
+    #[test]
+    fn test_svg_cnc_mill_still_works() {
+        let svg = r#"<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+            <rect x="10" y="10" width="80" height="80"/>
+        </svg>"#;
+        let config_json = r#"{"strategy": "contour"}"#;
+        let result = process_svg(svg, config_json);
+        assert!(result.is_ok());
+        let gcode = result.unwrap();
+        assert!(gcode.contains("M3 S12000"), "Should have spindle on");
+    }
+
+    #[test]
+    fn test_available_profiles() {
+        let json = available_profiles();
+        let profiles: Vec<MachineProfile> = serde_json::from_str(&json).unwrap();
+        assert_eq!(profiles.len(), 2);
+        assert_eq!(profiles[0].machine_type, MachineType::CncMill);
+        assert_eq!(profiles[1].machine_type, MachineType::LaserCutter);
+    }
+
+    #[test]
+    fn test_default_config_cnc() {
+        let json = default_config("cnc_mill");
+        let config: CamConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(config.machine_type, "cnc_mill");
+        assert_eq!(config.strategy, "contour");
+    }
+
+    #[test]
+    fn test_default_config_laser() {
+        let json = default_config("laser_cutter");
+        let config: CamConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(config.machine_type, "laser_cutter");
+        assert_eq!(config.strategy, "laser_cut");
+        assert_eq!(config.laser_power, Some(100.0));
+        assert_eq!(config.passes, Some(1));
     }
 }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1,0 +1,208 @@
+//! Machine profile system for CNC mill and laser cutter support.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum MachineType {
+    #[default]
+    CncMill,
+    LaserCutter,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MachineCapabilities {
+    pub available_strategies: Vec<String>,
+    pub has_spindle: bool,
+    pub has_laser_power: bool,
+    pub has_z_axis: bool,
+    pub max_feed_rate: f64,
+    pub max_spindle_rpm: Option<f64>,
+    pub max_laser_power: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutputConfig {
+    pub preamble: Vec<String>,
+    pub postamble: Vec<String>,
+    pub unit_mode: String,
+    pub distance_mode: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MachineProfile {
+    pub name: String,
+    pub machine_type: MachineType,
+    pub capabilities: MachineCapabilities,
+    pub output_config: OutputConfig,
+}
+
+impl MachineProfile {
+    /// Default CNC mill profile with all current strategies.
+    pub fn cnc_mill() -> Self {
+        Self {
+            name: "CNC Mill".into(),
+            machine_type: MachineType::CncMill,
+            capabilities: MachineCapabilities {
+                available_strategies: vec![
+                    "contour".into(),
+                    "pocket".into(),
+                    "slice".into(),
+                    "zigzag".into(),
+                    "perimeter".into(),
+                ],
+                has_spindle: true,
+                has_laser_power: false,
+                has_z_axis: true,
+                max_feed_rate: 10000.0,
+                max_spindle_rpm: Some(30000.0),
+                max_laser_power: None,
+            },
+            output_config: OutputConfig {
+                preamble: vec!["G21 (metric)".into(), "G90 (absolute positioning)".into()],
+                postamble: vec![
+                    "M5 (spindle off)".into(),
+                    "M9 (coolant off)".into(),
+                    "G0 X0 Y0".into(),
+                    "M2 (program end)".into(),
+                ],
+                unit_mode: "G21".into(),
+                distance_mode: "G90".into(),
+            },
+        }
+    }
+
+    /// Default laser cutter profile with 2D-only strategies.
+    pub fn laser_cutter() -> Self {
+        Self {
+            name: "Laser Cutter".into(),
+            machine_type: MachineType::LaserCutter,
+            capabilities: MachineCapabilities {
+                available_strategies: vec![
+                    "contour".into(),
+                    "pocket".into(),
+                    "perimeter".into(),
+                    "laser_cut".into(),
+                    "laser_engrave".into(),
+                ],
+                has_spindle: false,
+                has_laser_power: true,
+                has_z_axis: false,
+                max_feed_rate: 20000.0,
+                max_spindle_rpm: None,
+                max_laser_power: Some(100.0),
+            },
+            output_config: OutputConfig {
+                preamble: vec![
+                    "G21 (metric)".into(),
+                    "G90 (absolute positioning)".into(),
+                    "M4 S0 (dynamic laser mode)".into(),
+                ],
+                postamble: vec![
+                    "M5 (laser off)".into(),
+                    "G0 X0 Y0".into(),
+                    "M2 (program end)".into(),
+                ],
+                unit_mode: "G21".into(),
+                distance_mode: "G90".into(),
+            },
+        }
+    }
+
+    /// Returns true if the given strategy is supported by this profile.
+    pub fn supports_strategy(&self, strategy: &str) -> bool {
+        self.capabilities
+            .available_strategies
+            .iter()
+            .any(|s| s == strategy)
+    }
+
+    /// Validate that a strategy is allowed for this machine type.
+    /// Returns an error message if the strategy is rejected.
+    pub fn validate_strategy(&self, strategy: &str) -> Result<(), String> {
+        // 3D strategies are not valid for laser cutters
+        if self.machine_type == MachineType::LaserCutter && matches!(strategy, "zigzag" | "slice") {
+            return Err(format!(
+                "Strategy '{}' requires Z-axis which laser cutter does not have",
+                strategy
+            ));
+        }
+        if !self.supports_strategy(strategy) {
+            return Err(format!(
+                "Strategy '{}' is not available for {}",
+                strategy, self.name
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Default for MachineProfile {
+    fn default() -> Self {
+        Self::cnc_mill()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cnc_mill_has_all_strategies() {
+        let profile = MachineProfile::cnc_mill();
+        assert!(profile.supports_strategy("contour"));
+        assert!(profile.supports_strategy("pocket"));
+        assert!(profile.supports_strategy("slice"));
+        assert!(profile.supports_strategy("zigzag"));
+        assert!(profile.supports_strategy("perimeter"));
+    }
+
+    #[test]
+    fn laser_rejects_3d_strategies() {
+        let profile = MachineProfile::laser_cutter();
+        assert!(profile.validate_strategy("zigzag").is_err());
+        assert!(profile.validate_strategy("slice").is_err());
+    }
+
+    #[test]
+    fn laser_accepts_2d_strategies() {
+        let profile = MachineProfile::laser_cutter();
+        assert!(profile.validate_strategy("contour").is_ok());
+        assert!(profile.validate_strategy("pocket").is_ok());
+        assert!(profile.validate_strategy("laser_cut").is_ok());
+        assert!(profile.validate_strategy("laser_engrave").is_ok());
+    }
+
+    #[test]
+    fn cnc_mill_has_spindle() {
+        let profile = MachineProfile::cnc_mill();
+        assert!(profile.capabilities.has_spindle);
+        assert!(!profile.capabilities.has_laser_power);
+        assert!(profile.capabilities.has_z_axis);
+    }
+
+    #[test]
+    fn laser_has_laser_power() {
+        let profile = MachineProfile::laser_cutter();
+        assert!(!profile.capabilities.has_spindle);
+        assert!(profile.capabilities.has_laser_power);
+        assert!(!profile.capabilities.has_z_axis);
+    }
+
+    #[test]
+    fn machine_type_serde() {
+        let json = serde_json::to_string(&MachineType::CncMill).unwrap();
+        assert_eq!(json, "\"cnc_mill\"");
+        let json = serde_json::to_string(&MachineType::LaserCutter).unwrap();
+        assert_eq!(json, "\"laser_cutter\"");
+    }
+
+    #[test]
+    fn profile_serde_roundtrip() {
+        let profile = MachineProfile::cnc_mill();
+        let json = serde_json::to_string(&profile).unwrap();
+        let p2: MachineProfile = serde_json::from_str(&json).unwrap();
+        assert_eq!(p2.name, "CNC Mill");
+        assert_eq!(p2.machine_type, MachineType::CncMill);
+    }
+}

--- a/src/toolpath.rs
+++ b/src/toolpath.rs
@@ -352,12 +352,18 @@ impl ZigzagSurfaceStrategy {
                     let x_range: Vec<f64> = if forward {
                         float_range(x_min, x_max, step).collect()
                     } else {
-                        float_range(x_min, x_max, step).collect::<Vec<_>>().into_iter().rev().collect()
+                        float_range(x_min, x_max, step)
+                            .collect::<Vec<_>>()
+                            .into_iter()
+                            .rev()
+                            .collect()
                     };
 
                     let row: Vec<(f64, f64, f64)> = x_range
                         .into_iter()
-                        .filter_map(|x| Self::sample_point(params.mesh, x, y, is_ball_end, tool_radius))
+                        .filter_map(|x| {
+                            Self::sample_point(params.mesh, x, y, is_ball_end, tool_radius)
+                        })
                         .collect();
 
                     if !row.is_empty() {
@@ -381,12 +387,18 @@ impl ZigzagSurfaceStrategy {
                     let y_range: Vec<f64> = if forward {
                         float_range(y_min, y_max, step).collect()
                     } else {
-                        float_range(y_min, y_max, step).collect::<Vec<_>>().into_iter().rev().collect()
+                        float_range(y_min, y_max, step)
+                            .collect::<Vec<_>>()
+                            .into_iter()
+                            .rev()
+                            .collect()
                     };
 
                     let col: Vec<(f64, f64, f64)> = y_range
                         .into_iter()
-                        .filter_map(|y| Self::sample_point(params.mesh, x, y, is_ball_end, tool_radius))
+                        .filter_map(|y| {
+                            Self::sample_point(params.mesh, x, y, is_ball_end, tool_radius)
+                        })
                         .collect();
 
                     if !col.is_empty() {
@@ -412,15 +424,14 @@ impl ZigzagSurfaceStrategy {
             let mut tp = Toolpath::new();
             let (x0, y0, z0) = row[0];
 
-            if prev_end.is_none() {
-                // First row: rapid to safe Z then plunge
-                tp.rapid(x0, y0, safe_z);
-                tp.cut(x0, y0, z0);
-            } else {
+            if let Some((px, py, pz)) = prev_end {
                 // Subsequent rows: cut directly from previous row end
                 // (staying on the surface, no retract)
-                let (px, py, pz) = prev_end.unwrap();
                 tp.cut(px, py, pz);
+                tp.cut(x0, y0, z0);
+            } else {
+                // First row: rapid to safe Z then plunge
+                tp.rapid(x0, y0, safe_z);
                 tp.cut(x0, y0, z0);
             }
 
@@ -441,6 +452,121 @@ impl ZigzagSurfaceStrategy {
             }
         }
 
+        toolpaths
+    }
+}
+
+// ── Laser cut strategy ──────────────────────────────────────────────
+
+/// Laser cut strategy: follows contour paths at Z=0 with power metadata.
+/// Supports multi-pass via the `passes` field in CutParams (or via emitter).
+pub struct LaserCutStrategy {
+    pub power: f64,
+}
+
+impl LaserCutStrategy {
+    pub fn new(power: f64) -> Self {
+        Self { power }
+    }
+}
+
+impl ToolpathStrategy for LaserCutStrategy {
+    fn generate(&self, contours: &[Polyline], _params: &CutParams) -> Vec<Toolpath> {
+        let mut toolpaths = Vec::new();
+
+        for contour in contours {
+            if contour.points.is_empty() {
+                continue;
+            }
+
+            let mut tp = Toolpath::new();
+            let first = contour.points[0];
+
+            // Rapid to start (no Z movement for laser)
+            tp.rapid(first.x, first.y, 0.0);
+
+            // Cut along contour with power
+            for pt in &contour.points[1..] {
+                tp.cut_with_power(pt.x, pt.y, 0.0, self.power);
+            }
+
+            // Close if needed
+            if contour.closed && contour.points.len() > 1 {
+                tp.cut_with_power(first.x, first.y, 0.0, self.power);
+            }
+
+            toolpaths.push(tp);
+        }
+        toolpaths
+    }
+}
+
+// ── Laser engrave strategy ──────────────────────────────────────────
+
+/// Laser engrave strategy: scanline fill of closed paths.
+/// Bidirectional serpentine pattern with configurable line spacing.
+pub struct LaserEngraveStrategy {
+    pub power: f64,
+    pub line_spacing: f64,
+}
+
+impl LaserEngraveStrategy {
+    pub fn new(power: f64, line_spacing: f64) -> Self {
+        Self {
+            power,
+            line_spacing: line_spacing.max(0.1),
+        }
+    }
+}
+
+impl ToolpathStrategy for LaserEngraveStrategy {
+    fn generate(&self, contours: &[Polyline], _params: &CutParams) -> Vec<Toolpath> {
+        let mut toolpaths = Vec::new();
+
+        for contour in contours {
+            if contour.points.len() < 3 || !contour.closed {
+                continue;
+            }
+
+            let bounds = match contour.bounds() {
+                Some(b) => b,
+                None => continue,
+            };
+
+            let y_min = bounds.min.y;
+            let y_max = bounds.max.y;
+
+            let mut tp = Toolpath::new();
+            let mut y = y_min;
+            let mut forward = true;
+
+            while y <= y_max {
+                let mut xs = scanline_intersect(contour, y);
+                xs.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+                for pair in xs.chunks(2) {
+                    if pair.len() < 2 {
+                        continue;
+                    }
+                    let x0 = pair[0];
+                    let x1 = pair[1];
+                    if x0 >= x1 {
+                        continue;
+                    }
+
+                    let (start_x, end_x) = if forward { (x0, x1) } else { (x1, x0) };
+
+                    tp.rapid(start_x, y, 0.0);
+                    tp.cut_with_power(end_x, y, 0.0, self.power);
+                }
+                forward = !forward;
+                y += self.line_spacing;
+            }
+
+            if !tp.moves.is_empty() {
+                toolpaths.push(tp);
+            }
+        }
         toolpaths
     }
 }
@@ -1042,5 +1168,110 @@ mod tests {
             "Pass 2 should be inward by at least step_over/2: {}",
             offset_diff
         );
+    }
+
+    // ── Laser cut strategy tests ──────────────────────────────────────
+
+    #[test]
+    fn test_laser_cut_follows_contour() {
+        let contours = vec![square()];
+        let strategy = LaserCutStrategy::new(80.0);
+        let toolpaths = strategy.generate(&contours, &CutParams::default());
+        assert_eq!(toolpaths.len(), 1);
+        // Should have rapid + 4 cuts + close = 6 moves
+        assert!(toolpaths[0].moves.len() >= 5);
+    }
+
+    #[test]
+    fn test_laser_cut_at_z_zero() {
+        let contours = vec![square()];
+        let strategy = LaserCutStrategy::new(50.0);
+        let toolpaths = strategy.generate(&contours, &CutParams::default());
+        for mv in &toolpaths[0].moves {
+            assert!((mv.z - 0.0).abs() < 0.001, "Laser should operate at Z=0");
+        }
+    }
+
+    #[test]
+    fn test_laser_cut_has_power() {
+        let contours = vec![square()];
+        let strategy = LaserCutStrategy::new(75.0);
+        let toolpaths = strategy.generate(&contours, &CutParams::default());
+        let cuts: Vec<_> = toolpaths[0].moves.iter().filter(|m| !m.rapid).collect();
+        assert!(!cuts.is_empty());
+        for cut in &cuts {
+            assert_eq!(cut.power, Some(75.0));
+        }
+    }
+
+    #[test]
+    fn test_laser_cut_closes_path() {
+        let contours = vec![square()]; // closed polyline
+        let strategy = LaserCutStrategy::new(80.0);
+        let toolpaths = strategy.generate(&contours, &CutParams::default());
+        let moves = &toolpaths[0].moves;
+        // First move is rapid to start point; last move should return there (closing)
+        let first = &moves[0];
+        let last = moves.last().unwrap();
+        assert!((last.x - first.x).abs() < 0.01);
+        assert!((last.y - first.y).abs() < 0.01);
+    }
+
+    // ── Laser engrave strategy tests ──────────────────────────────────
+
+    #[test]
+    fn test_laser_engrave_scanlines() {
+        let contours = vec![square()]; // 10x10 closed square
+        let strategy = LaserEngraveStrategy::new(60.0, 1.0);
+        let toolpaths = strategy.generate(&contours, &CutParams::default());
+        assert!(!toolpaths.is_empty());
+        // Should have multiple scanlines
+        assert!(toolpaths[0].moves.len() > 10);
+    }
+
+    #[test]
+    fn test_laser_engrave_at_z_zero() {
+        let contours = vec![square()];
+        let strategy = LaserEngraveStrategy::new(60.0, 1.0);
+        let toolpaths = strategy.generate(&contours, &CutParams::default());
+        for mv in &toolpaths[0].moves {
+            assert!((mv.z - 0.0).abs() < 0.001, "Engrave should operate at Z=0");
+        }
+    }
+
+    #[test]
+    fn test_laser_engrave_has_power() {
+        let contours = vec![square()];
+        let strategy = LaserEngraveStrategy::new(42.0, 1.0);
+        let toolpaths = strategy.generate(&contours, &CutParams::default());
+        let cuts: Vec<_> = toolpaths[0].moves.iter().filter(|m| !m.rapid).collect();
+        assert!(!cuts.is_empty());
+        for cut in &cuts {
+            assert_eq!(cut.power, Some(42.0));
+        }
+    }
+
+    #[test]
+    fn test_laser_engrave_skips_open_paths() {
+        let open = Polyline::new(vec![Vec2::new(0.0, 0.0), Vec2::new(10.0, 10.0)], false);
+        let strategy = LaserEngraveStrategy::new(60.0, 1.0);
+        let toolpaths = strategy.generate(&[open], &CutParams::default());
+        assert!(toolpaths.is_empty(), "Should skip open polylines");
+    }
+
+    #[test]
+    fn test_laser_engrave_serpentine() {
+        let contours = vec![square()];
+        let strategy = LaserEngraveStrategy::new(60.0, 2.0);
+        let toolpaths = strategy.generate(&contours, &CutParams::default());
+        // Find cutting moves to check direction alternates
+        let cuts: Vec<_> = toolpaths[0].moves.iter().filter(|m| !m.rapid).collect();
+        if cuts.len() >= 2 {
+            // First and second cut lines should go in different X directions
+            // (alternating forward/backward)
+            let first_dx = cuts[0].x;
+            // Just verify we have valid moves
+            assert!(first_dx.is_finite());
+        }
     }
 }

--- a/src/units.rs
+++ b/src/units.rs
@@ -1,0 +1,249 @@
+//! Type-safe physical units for CNC operations.
+//!
+//! Uses phantom types to enforce unit correctness at compile time.
+//! Ported from cnc-sender with serde support added for JSON config.
+
+use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
+
+/// Sealed trait for distance units.
+pub trait DistanceUnit: private::Sealed + Copy + Clone + std::fmt::Debug + Default {
+    const NAME: &'static str;
+    const TO_MM: f64;
+}
+
+mod private {
+    pub trait Sealed {}
+    impl Sealed for super::Millimeters {}
+    impl Sealed for super::Inches {}
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Millimeters;
+
+impl DistanceUnit for Millimeters {
+    const NAME: &'static str = "mm";
+    const TO_MM: f64 = 1.0;
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Inches;
+
+impl DistanceUnit for Inches {
+    const NAME: &'static str = "in";
+    const TO_MM: f64 = 25.4;
+}
+
+/// Type-safe distance value with unit phantom type.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Distance<U: DistanceUnit> {
+    value: f64,
+    _unit: PhantomData<U>,
+}
+
+impl<U: DistanceUnit> Serialize for Distance<U> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.value.serialize(serializer)
+    }
+}
+
+impl<'de, U: DistanceUnit> Deserialize<'de> for Distance<U> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        f64::deserialize(deserializer).map(Self::new)
+    }
+}
+
+impl<U: DistanceUnit> Distance<U> {
+    #[must_use]
+    pub const fn new(value: f64) -> Self {
+        Self {
+            value,
+            _unit: PhantomData,
+        }
+    }
+
+    #[must_use]
+    pub const fn value(self) -> f64 {
+        self.value
+    }
+
+    #[must_use]
+    pub fn to_mm(self) -> f64 {
+        self.value * U::TO_MM
+    }
+
+    #[must_use]
+    pub const fn unit_name() -> &'static str {
+        U::NAME
+    }
+
+    #[must_use]
+    pub const fn zero() -> Self {
+        Self::new(0.0)
+    }
+
+    #[must_use]
+    pub fn abs(self) -> Self {
+        Self::new(self.value.abs())
+    }
+}
+
+impl<U: DistanceUnit> std::ops::Neg for Distance<U> {
+    type Output = Self;
+    fn neg(self) -> Self::Output {
+        Self::new(-self.value)
+    }
+}
+
+impl<U: DistanceUnit> Default for Distance<U> {
+    fn default() -> Self {
+        Self::zero()
+    }
+}
+
+impl<U: DistanceUnit> std::ops::Add for Distance<U> {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self::Output {
+        Self::new(self.value + rhs.value)
+    }
+}
+
+impl<U: DistanceUnit> std::ops::Sub for Distance<U> {
+    type Output = Self;
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self::new(self.value - rhs.value)
+    }
+}
+
+impl<U: DistanceUnit> std::ops::Mul<f64> for Distance<U> {
+    type Output = Self;
+    fn mul(self, rhs: f64) -> Self::Output {
+        Self::new(self.value * rhs)
+    }
+}
+
+impl<U: DistanceUnit> std::fmt::Display for Distance<U> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:.3} {}", self.value, U::NAME)
+    }
+}
+
+/// Feed rate in units per minute.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct FeedRate<U: DistanceUnit> {
+    value: f64,
+    _unit: PhantomData<U>,
+}
+
+impl<U: DistanceUnit> Serialize for FeedRate<U> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.value.serialize(serializer)
+    }
+}
+
+impl<'de, U: DistanceUnit> Deserialize<'de> for FeedRate<U> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        f64::deserialize(deserializer).map(Self::new)
+    }
+}
+
+impl<U: DistanceUnit> FeedRate<U> {
+    #[must_use]
+    pub const fn new(value: f64) -> Self {
+        Self {
+            value,
+            _unit: PhantomData,
+        }
+    }
+
+    #[must_use]
+    pub const fn value(self) -> f64 {
+        self.value
+    }
+
+    #[must_use]
+    pub fn to_mm_per_min(self) -> f64 {
+        self.value * U::TO_MM
+    }
+}
+
+impl<U: DistanceUnit> Default for FeedRate<U> {
+    fn default() -> Self {
+        Self::new(0.0)
+    }
+}
+
+impl<U: DistanceUnit> std::fmt::Display for FeedRate<U> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:.0} {}/min", self.value, U::NAME)
+    }
+}
+
+/// Spindle speed in RPM.
+#[derive(
+    Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+pub struct SpindleSpeed(pub u32);
+
+impl SpindleSpeed {
+    #[must_use]
+    pub const fn new(rpm: u32) -> Self {
+        Self(rpm)
+    }
+
+    #[must_use]
+    pub const fn rpm(self) -> u32 {
+        self.0
+    }
+
+    pub const OFF: Self = Self(0);
+}
+
+impl std::fmt::Display for SpindleSpeed {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} RPM", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn distance_operations() {
+        let d1 = Distance::<Millimeters>::new(10.0);
+        let d2 = Distance::<Millimeters>::new(5.0);
+        assert_eq!((d1 + d2).value(), 15.0);
+        assert_eq!((d1 - d2).value(), 5.0);
+        assert_eq!((d1 * 2.0).value(), 20.0);
+    }
+
+    #[test]
+    fn distance_conversion() {
+        let inches = Distance::<Inches>::new(1.0);
+        assert!((inches.to_mm() - 25.4).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn feed_rate_display() {
+        let feed = FeedRate::<Millimeters>::new(1000.0);
+        assert_eq!(format!("{feed}"), "1000 mm/min");
+    }
+
+    #[test]
+    fn distance_serde_roundtrip() {
+        let d = Distance::<Millimeters>::new(42.5);
+        let json = serde_json::to_string(&d).unwrap();
+        assert_eq!(json, "42.5");
+        let d2: Distance<Millimeters> = serde_json::from_str(&json).unwrap();
+        assert_eq!(d, d2);
+    }
+
+    #[test]
+    fn spindle_speed_serde() {
+        let s = SpindleSpeed::new(12000);
+        let json = serde_json::to_string(&s).unwrap();
+        let s2: SpindleSpeed = serde_json::from_str(&json).unwrap();
+        assert_eq!(s, s2);
+    }
+}

--- a/www/index.html
+++ b/www/index.html
@@ -186,6 +186,13 @@ canvas { flex: 1; width: 100%; height: 100%; display: block; }
       <input type="file" id="file-input" accept=".stl,.svg" hidden/>
     </section>
     <section>
+      <h2>Machine</h2>
+      <select id="machine-type">
+        <option value="cnc_mill">CNC Mill</option>
+        <option value="laser_cutter">Laser Cutter</option>
+      </select>
+    </section>
+    <section>
       <h2>Strategy</h2>
       <select id="strategy">
         <option value="contour">Contour (profile cut)</option>
@@ -193,6 +200,8 @@ canvas { flex: 1; width: 100%; height: 100%; display: block; }
         <option value="slice">Slice (layer contour)</option>
         <option value="zigzag">Zigzag Surface</option>
         <option value="perimeter">Perimeter</option>
+        <option value="laser_cut">Laser Cut</option>
+        <option value="laser_engrave">Laser Engrave</option>
       </select>
     </section>
     <section>
@@ -233,7 +242,7 @@ canvas { flex: 1; width: 100%; height: 100%; display: block; }
       <label>Number of passes</label>
       <input type="number" id="perimeter-passes" value="1" step="1" min="1"/>
     </section>
-    <section>
+    <section id="cnc-params">
       <h2>Cutting</h2>
       <label>Cut depth (mm, negative)</label>
       <input type="number" id="cut-depth" value="-1" step="0.5"/>
@@ -247,6 +256,19 @@ canvas { flex: 1; width: 100%; height: 100%; display: block; }
       <input type="number" id="spindle-speed" value="12000" step="500" min="0"/>
       <label>Safe Z (mm)</label>
       <input type="number" id="safe-z" value="5" step="1" min="0.5"/>
+    </section>
+    <section id="laser-params" style="display:none;">
+      <h2>Laser</h2>
+      <label>Laser power (%)</label>
+      <input type="number" id="laser-power" value="100" step="5" min="0" max="100"/>
+      <label>Feed rate (mm/min)</label>
+      <input type="number" id="laser-feed-rate" value="1000" step="50" min="1"/>
+      <label>Number of passes</label>
+      <input type="number" id="laser-passes" value="1" step="1" min="1"/>
+      <label>
+        <input type="checkbox" id="air-assist"/>
+        Air assist
+      </label>
     </section>
     <section>
       <button class="btn btn-primary" id="generate-btn" disabled>Generate G-code</button>
@@ -299,6 +321,7 @@ import init, {
   process_stl, process_svg,
   preview_stl, preview_svg,
   sim_moves_stl, sim_moves_svg,
+  available_profiles, default_config,
 } from './pkg/rustcam.js';
 
 let wasmReady = false;
@@ -334,6 +357,35 @@ function updateToolTypeUI() {
 toolTypeSelect.addEventListener('change', updateToolTypeUI);
 document.getElementById('tool-diameter').addEventListener('change', updateToolTypeUI);
 
+// ── Machine type UI ───────────────────────────────────────────────────
+const machineTypeSelect = document.getElementById('machine-type');
+const cncParamsSection = document.getElementById('cnc-params');
+const laserParamsSection = document.getElementById('laser-params');
+
+const cncStrategies = ['contour', 'pocket', 'slice', 'zigzag', 'perimeter'];
+const laserStrategies = ['contour', 'pocket', 'perimeter', 'laser_cut', 'laser_engrave'];
+
+function updateMachineTypeUI() {
+  const isLaser = machineTypeSelect.value === 'laser_cutter';
+  cncParamsSection.style.display = isLaser ? 'none' : 'block';
+  laserParamsSection.style.display = isLaser ? 'block' : 'none';
+
+  // Update available strategies
+  const strategySelect = document.getElementById('strategy');
+  const current = strategySelect.value;
+  const allowed = isLaser ? laserStrategies : cncStrategies;
+  for (const opt of strategySelect.options) {
+    opt.hidden = !allowed.includes(opt.value);
+  }
+  // If current strategy is not available, switch to first available
+  if (!allowed.includes(current)) {
+    strategySelect.value = isLaser ? 'laser_cut' : 'contour';
+  }
+  updateStrategyUI();
+}
+
+machineTypeSelect.addEventListener('change', () => { updateMachineTypeUI(); tryPreview(); });
+
 // ── Strategy UI ───────────────────────────────────────────────────────
 const strategySelect = document.getElementById('strategy');
 const perimeterOptions = document.getElementById('perimeter-options');
@@ -347,7 +399,7 @@ function updateStrategyUI() {
 
 strategySelect.addEventListener('change', () => { updateStrategyUI(); tryPreview(); });
 document.getElementById('scan-direction').addEventListener('change', tryPreview);
-updateStrategyUI();
+updateMachineTypeUI();
 
 // ── Tabs ─────────────────────────────────────────────────────────────
 document.querySelectorAll('.tab-bar button').forEach(btn => {
@@ -412,18 +464,33 @@ function handleFile(file) {
 // ── Config ───────────────────────────────────────────────────────────
 function getConfig() {
   const toolType = document.getElementById('tool-type').value;
+  const isLaser = machineTypeSelect.value === 'laser_cutter';
   const config = {
     tool_diameter:  parseFloat(document.getElementById('tool-diameter').value),
     step_over:      parseFloat(document.getElementById('step-over').value),
-    step_down:      parseFloat(document.getElementById('step-down').value),
-    feed_rate:      parseFloat(document.getElementById('feed-rate').value),
-    plunge_rate:    parseFloat(document.getElementById('plunge-rate').value),
-    spindle_speed:  parseFloat(document.getElementById('spindle-speed').value),
-    safe_z:         parseFloat(document.getElementById('safe-z').value),
-    cut_depth:      parseFloat(document.getElementById('cut-depth').value),
     strategy:       document.getElementById('strategy').value,
     tool_type:      toolType,
+    machine_type:   machineTypeSelect.value,
   };
+
+  if (isLaser) {
+    config.feed_rate = parseFloat(document.getElementById('laser-feed-rate').value);
+    config.plunge_rate = config.feed_rate;
+    config.spindle_speed = 0;
+    config.safe_z = 0;
+    config.cut_depth = 0;
+    config.step_down = 1;
+    config.laser_power = parseFloat(document.getElementById('laser-power').value);
+    config.passes = parseInt(document.getElementById('laser-passes').value) || 1;
+    config.air_assist = document.getElementById('air-assist').checked;
+  } else {
+    config.step_down = parseFloat(document.getElementById('step-down').value);
+    config.feed_rate = parseFloat(document.getElementById('feed-rate').value);
+    config.plunge_rate = parseFloat(document.getElementById('plunge-rate').value);
+    config.spindle_speed = parseFloat(document.getElementById('spindle-speed').value);
+    config.safe_z = parseFloat(document.getElementById('safe-z').value);
+    config.cut_depth = parseFloat(document.getElementById('cut-depth').value);
+  }
   // Add tool-type-specific parameters
   if (toolType === 'ball_end') {
     config.corner_radius = parseFloat(document.getElementById('corner-radius').value) || 0;
@@ -492,8 +559,16 @@ function drawPreview(paths) {
   const tx = x => offX+(x-minX)*scale;
   const ty = y => offY+(maxY-y)*scale;
 
+  // Color scheme depends on machine type
+  const isLaserPreview = machineTypeSelect.value === 'laser_cutter';
+
   // Color gradient by Z height (blue=low, green=mid, yellow=high)
+  // or red opacity for laser power
   const zColor = (z) => {
+    if (isLaserPreview) {
+      // For laser: red with varying opacity
+      return 'rgba(255, 60, 40, 0.85)';
+    }
     if (!has3D || z === undefined) return '#4f8cff';
     const t = (z - minZ) / zRange; // 0 to 1
     // HSL: 240 (blue) -> 120 (green) -> 60 (yellow)
@@ -520,8 +595,8 @@ function drawPreview(paths) {
         ctx.stroke();
       }
     } else {
-      // 2D paths: single color
-      ctx.strokeStyle='#4f8cff';
+      // 2D paths: blue for CNC, red for laser
+      ctx.strokeStyle = isLaserPreview ? 'rgba(255, 60, 40, 0.85)' : '#4f8cff';
       ctx.beginPath();
       ctx.moveTo(tx(p[0][0]),ty(p[0][1]));
       for(let i=1;i<p.length;i++)ctx.lineTo(tx(p[i][0]),ty(p[i][1]));


### PR DESCRIPTION
Add a machine profile abstraction supporting CNC mill and laser cutter machine types, with profile-aware G-code emission, laser-specific toolpath strategies, and UI for switching between machine types.

New modules:
- units.rs: Type-safe phantom-type unit system (Distance, FeedRate, SpindleSpeed) ported from cnc-sender with serde support
- gcode_parser.rs: G-code parser and validator ported from cnc-sender (command types, parse_line, validate_command, ValidationConfig)
- machine.rs: MachineProfile with MachineType enum, capabilities, output config, and strategy validation

Core changes:
- Profile-aware G-code emitter (CNC: spindle/Z-retract, Laser: M4 dynamic mode/S-power/no-Z) with multi-pass support
- LaserCutStrategy: contour following at Z=0 with power metadata
- LaserEngraveStrategy: bidirectional scanline fill of closed paths
- ToolpathMove gains optional power field for laser intensity
- CamConfig extended with machine_type, laser_power, passes, air_assist
- WASM API: available_profiles(), default_config(machine_type)
- Post-generation G-code validation with profile-specific rules
- UI: machine type selector, conditional CNC/laser parameter sections, strategy filtering by machine type, red preview for laser paths

109 tests (up from 85), all passing.