### PR TITLE
feat: CAD/CAM MVP with machine tool profiles

### DIFF
--- a/.claude/tasks.toml
+++ b/.claude/tasks.toml
@@ -2,218 +2,224 @@ version = 1
 status = "complete"
 
 [project]
-name = "rustcam-3d-surface"
-description = "Add zigzag 3D surface machining, perimeter strategy, and custom face mill tools"
+name = "webcam-cadcam-mvp"
+description = "CAD/CAM MVP with machine tool profiles (CNC mill, laser cutter), porting useful Rust code from cnc-sender, all running in WASM"
 worktree_base = ".worktrees"
 
-# ─── Foundation: Tool Definitions ───────────────────────────────────────────
+# ============================================================================
+# Phase 1: Port cnc-sender Foundation Types (parallel, no deps)
+# ============================================================================
 
 [[tasks]]
 id = "task-001"
-title = "Define Tool struct with geometry types"
+title = "Port type-safe unit system from cnc-sender"
 acceptance = """
-- Tool struct with: tool_type (EndMill, BallEnd, FaceMill), diameter, flute_length, corner_radius
-- FaceMill variant includes effective_diameter field
-- All fields have sensible defaults
-- Unit tests verify Tool construction and defaults
-- cargo test passes, no warnings
+- src/units.rs with Distance<Mm>/Distance<Inch>, FeedRate<U>, SpindleSpeed phantom types
+- Ported from ../cnc-sender/crates/cnc-types/src/units.rs
+- Compile-time unit safety prevents mixing mm and inch values
+- Conversion methods: Distance<Mm>::to_inches(), Distance<Inch>::to_mm()
+- Existing CamConfig/CutParams fields annotated or wrapped with typed units
+- All existing tests pass, new unit tests for conversions and Display
+- Builds for both native and wasm32-unknown-unknown targets
 """
 deps = []
 status = "complete"
+spec_file = "specs/task-001.md"
 
 [[tasks]]
 id = "task-002"
-title = "Extend CutParams to include Tool reference"
+title = "Port G-code parser and validator from cnc-sender"
 acceptance = """
-- CutParams includes tool: Tool field
-- Existing strategies use tool.diameter instead of tool_diameter
-- Backward compatible: tool_diameter still works via Tool::default()
-- All existing tests pass unchanged
+- src/gcode_parser.rs ported from ../cnc-sender/crates/cnc-gcode/src/parser.rs
+- parse_line() returns GCodeCommand enum (G0/G1/G2/G3, G20/G21, G90/G91, M3/M4/M5, M7-M9, S, F)
+- Comment stripping (semicolon and parenthetical)
+- src/gcode_validator.rs ported from ../cnc-sender/crates/cnc-gcode/src/validator.rs
+- ValidationConfig with configurable max feed, max spindle, travel bounds
+- Unit tests covering all supported G-codes and edge cases
+- WASM-compatible (no std::io, no std::fs)
 """
-deps = ["task-001"]
+deps = []
 status = "complete"
+spec_file = "specs/task-002.md"
+
+# ============================================================================
+# Phase 2: Machine Profile System
+# ============================================================================
 
 [[tasks]]
 id = "task-003"
-title = "Add tool type to CamConfig JSON schema"
+title = "Define MachineProfile and MachineType configuration"
 acceptance = """
-- CamConfig parses tool_type, corner_radius, effective_diameter from JSON
-- Default tool_type is 'end_mill'
-- process_stl and process_svg construct Tool from config
-- Existing JSON configs work without changes (backward compatible)
+- src/machine.rs with MachineType enum: CncMill, LaserCutter
+- MachineProfile struct: name, machine_type, capabilities, output_config
+- MachineCapabilities: available_strategies vec, has_spindle, has_laser_power, has_z_axis, max_feed_rate, max_spindle_rpm, max_laser_power
+- OutputConfig: preamble lines, postamble lines, unit_mode (G20/G21), distance_mode (G90/G91)
+- Serde Serialize/Deserialize for JSON config passing through WASM boundary
+- Default profiles: MachineProfile::cnc_mill(), MachineProfile::laser_cutter()
+- Unit tests for serialization roundtrip and default construction
 """
-deps = ["task-002"]
+deps = []
 status = "complete"
-
-# ─── 3D Surface Utilities ───────────────────────────────────────────────────
+spec_file = "specs/task-003.md"
 
 [[tasks]]
 id = "task-004"
-title = "Implement mesh height query at XY point"
+title = "Implement CNC mill profile with existing strategies"
 acceptance = """
-- Function: mesh_height_at(mesh: &Mesh, x: f64, y: f64) -> Option<f64>
-- Returns highest Z where ray from (x, y, +inf) intersects mesh
-- Returns None if no intersection (outside mesh bounds)
-- Unit tests with simple box and ramp meshes
+- CNC mill profile wraps existing behavior: spindle, Z-axis, all current strategies
+- CamConfig gains optional machine_type field (defaults to CncMill for backward compat)
+- Mill output config: G21 G90, M3 S{rpm}, optional M8 coolant, M5 M9 M30 end
+- process_stl/process_svg with machine_type='cnc_mill' produces identical output to current
+- Integration test: same STL input → identical G-code with and without explicit profile
 """
-deps = []
+deps = ["task-003"]
 status = "complete"
+spec_file = "specs/task-004.md"
 
 [[tasks]]
 id = "task-005"
-title = "Implement surface normal at XY point"
+title = "Implement laser cutter profile"
 acceptance = """
-- Function: surface_normal_at(mesh: &Mesh, x: f64, y: f64) -> Option<Vec3>
-- Returns interpolated normal of triangle at XY intersection
-- Used for ball-end tool contact point compensation
-- Unit tests verify normal direction on flat and angled surfaces
+- Laser profile: power (0-1000 S-value), dynamic power mode (M4), no Z-axis moves
+- Laser-specific CamConfig fields: laser_power, passes, air_assist bool
+- Laser output config: G21 G90, M4 S0 (dynamic power on), S{power} during cuts, M5 M30 end
+- Profile rejects 3D strategies (zigzag_surface, slice) with clear error message
+- Supports 2D strategies: contour, pocket (reused as engrave fill)
+- Rapid moves use S0 (power off) + G0 instead of Z retract
+- Unit tests for laser G-code output format
 """
-deps = ["task-004"]
+deps = ["task-003"]
 status = "complete"
-
-# ─── Zigzag Surface Strategy ────────────────────────────────────────────────
+spec_file = "specs/task-005.md"
 
 [[tasks]]
 id = "task-006"
-title = "Create SurfaceParams struct for 3D strategies"
+title = "Profile-aware G-code emitter"
 acceptance = """
-- SurfaceParams contains mesh reference, cut_params, scan_direction (X/Y)
-- Implements From<(&Mesh, &CutParams)> for easy construction
-- Does not break existing ToolpathStrategy trait
+- Refactored src/gcode.rs accepts MachineProfile for output formatting
+- emit_gcode(toolpath, profile) → String with correct preamble/postamble
+- CNC mill: G21 G90, M3 S{rpm}, rapids use safe_z retract, M5 M9 M30 end
+- Laser: G21 G90, M4 S0, rapids use S0 + G0 (no Z), S{power} during cuts, M5 M30 end
+- Existing gcode::emit() function delegates to profile-aware version with CncMill default
+- Tests comparing same toolpath output under both profiles
 """
-deps = ["task-002", "task-004"]
+deps = ["task-004", "task-005"]
 status = "complete"
+spec_file = "specs/task-006.md"
+
+# ============================================================================
+# Phase 3: Laser-Specific CAM Strategies
+# ============================================================================
 
 [[tasks]]
 id = "task-007"
-title = "Implement ZigzagSurfaceStrategy core loop"
+title = "Implement laser cut strategy (2D contour with power)"
 acceptance = """
-- ZigzagSurfaceStrategy implements new generate_surface method
-- Raster scan across mesh bounding box with step_over spacing
-- Queries mesh_height_at for each XY sample point
-- Skips points outside mesh (no intersection)
-- Alternates row direction for serpentine motion
+- LaserCutStrategy follows SVG contour paths with laser power metadata
+- Multi-pass support: repeat path N times (configurable passes parameter)
+- Lead-in overcut: small extension past path start for clean edge closure
+- ToolpathMove gains optional power: Option<f64> field for laser S-value
+- Generates flat (Z=0) toolpath with power on during cuts, power off during rapids
+- Unit tests: rectangle path → expected G-code with M4/S values
 """
-deps = ["task-004", "task-006"]
+deps = ["task-005"]
 status = "complete"
+spec_file = "specs/task-007.md"
 
 [[tasks]]
 id = "task-008"
-title = "Add ball-end tool compensation to zigzag"
+title = "Implement laser engrave strategy (raster fill)"
 acceptance = """
-- When tool_type is BallEnd, apply contact point offset
-- Offset = (radius * sin(angle), radius * cos(angle)) based on surface normal
-- Flat surfaces (normal = +Z) have no offset
-- Tests verify offset on 45-degree ramp
+- LaserEngraveStrategy: scanline fill of closed SVG paths
+- Bidirectional scanning (serpentine pattern, alternating row direction)
+- Configurable line spacing in mm (maps to DPI: spacing = 25.4/DPI)
+- Power level configurable per-job (uniform fill for MVP)
+- Efficient toolpath: minimizes laser-off travel between scanlines
+- Unit tests: filled 10x10mm rectangle at 0.1mm spacing → 100 scanlines
 """
-deps = ["task-005", "task-007"]
+deps = ["task-005"]
 status = "complete"
+spec_file = "specs/task-008.md"
+
+# ============================================================================
+# Phase 4: WASM API & UI Integration
+# ============================================================================
 
 [[tasks]]
 id = "task-009"
-title = "Wire ZigzagSurfaceStrategy into process_stl"
+title = "Update WASM API for machine profile selection"
 acceptance = """
-- 'zigzag' strategy option in CamConfig
-- process_stl selects ZigzagSurfaceStrategy when strategy='zigzag'
-- Generates valid G-code with 3D Z motion
-- Integration test with sample STL file
+- process_stl/process_svg config JSON accepts machine_type field
+- Omitting machine_type defaults to 'cnc_mill' (backward compatible)
+- New WASM export: available_profiles() → JSON [{name, machine_type, capabilities}]
+- New WASM export: default_config(machine_type) → JSON default config for that profile
+- preview functions respect profile (laser preview: no Z, power as metadata)
+- All existing www/index.html usage works without changes
 """
-deps = ["task-003", "task-008"]
+deps = ["task-006"]
 status = "complete"
-
-# ─── Perimeter Strategy ─────────────────────────────────────────────────────
+spec_file = "specs/task-009.md"
 
 [[tasks]]
 id = "task-010"
-title = "Implement PerimeterStrategy basic boundary follow"
+title = "Add machine profile selector to web UI"
 acceptance = """
-- PerimeterStrategy implements ToolpathStrategy
-- Follows outermost contour from slicing
-- Applies tool radius offset perpendicular to path
-- Single pass at specified Z depth
+- Machine type dropdown at top of parameter panel: 'CNC Mill', 'Laser Cutter'
+- Selecting profile shows/hides relevant parameter sections dynamically
+- CNC mill shows: spindle speed, plunge rate, step-down, safe-Z, tool type, coolant
+- Laser shows: power (0-100%), cut speed, passes, line spacing (for engrave), air assist
+- Strategy dropdown filtered to only valid strategies for selected profile
+- Profile persists in localStorage across page reloads
 """
-deps = ["task-002"]
+deps = ["task-009"]
 status = "complete"
+spec_file = "specs/task-010.md"
 
 [[tasks]]
 id = "task-011"
-title = "Add climb/conventional cut direction parameter"
+title = "Profile-aware canvas preview rendering"
 acceptance = """
-- CutParams or PerimeterStrategy config includes climb_cut: bool
-- climb_cut=true: tool left of path (CW for outside)
-- climb_cut=false: tool right of path (CCW for outside)
-- Tests verify direction reversal
+- CNC preview: existing Z-height color gradient (blue=safe, red=deep cut)
+- Laser preview: cut paths as red lines (opacity = power level), travel as gray dashed
+- Laser engrave preview: filled scanlines visible with power-based opacity
+- Preview updates immediately when switching profiles
+- Legend/key shows color meaning per profile type
 """
-deps = ["task-010"]
+deps = ["task-009"]
 status = "complete"
+spec_file = "specs/task-011.md"
+
+# ============================================================================
+# Phase 5: Integration & Validation
+# ============================================================================
 
 [[tasks]]
 id = "task-012"
-title = "Support multiple perimeter passes"
+title = "End-to-end integration tests for both profiles"
 acceptance = """
-- perimeter_passes: u32 parameter (default 1)
-- Each pass offset by step_over from previous
-- Innermost pass uses full tool offset
-- Generates concentric offset paths
+- Test: SVG rectangle → CNC mill contour → G-code with M3, Z moves, F rates
+- Test: SVG rectangle → laser cut → G-code with M4, S values, no Z moves
+- Test: SVG filled shape → laser engrave → G-code with scanlines and S values
+- Test: STL mesh → CNC zigzag surface → valid G-code (laser rejects STL gracefully)
+- Test: config JSON roundtrip for each profile type
+- Test: WASM build succeeds, exports available_profiles and default_config
+- All pass in `make verify`
 """
-deps = ["task-011"]
+deps = ["task-007", "task-008", "task-009"]
 status = "complete"
+spec_file = "specs/task-012.md"
 
 [[tasks]]
 id = "task-013"
-title = "Wire PerimeterStrategy into process_stl"
+title = "Post-generation G-code validation using ported parser"
 acceptance = """
-- 'perimeter' strategy option in CamConfig
-- Slices mesh then applies perimeter to each layer
-- Respects climb_cut and perimeter_passes params
-- Integration test produces valid G-code
+- Generated G-code piped through validator before returning to caller
+- Validator checks per profile: feed rate presence on G1, valid S range, expected axes
+- Laser: warns on any Z move (except focus), S within max_laser_power
+- CNC: warns on missing plunge rate for Z moves, S within max_spindle_rpm
+- Warnings returned as JSON array alongside G-code string (non-blocking)
+- Unit tests for each validation rule
 """
-deps = ["task-003", "task-012"]
+deps = ["task-002", "task-012"]
 status = "complete"
-
-# ─── Web UI Updates ─────────────────────────────────────────────────────────
-
-[[tasks]]
-id = "task-014"
-title = "Add strategy options to UI dropdown"
-acceptance = """
-- Strategy dropdown includes: Contour, Pocket, Slice, Zigzag Surface, Perimeter
-- Selection updates config.strategy value sent to WASM
-- Existing strategies still work
-"""
-deps = []
-status = "complete"
-
-[[tasks]]
-id = "task-015"
-title = "Add tool type selector to UI"
-acceptance = """
-- Tool type dropdown: End Mill, Ball End, Face Mill
-- Face Mill shows additional 'Effective Diameter' input
-- Ball End shows corner radius (equals radius for ball end)
-- Parameters included in JSON config
-"""
-deps = ["task-014"]
-status = "complete"
-
-[[tasks]]
-id = "task-016"
-title = "Add perimeter-specific parameters to UI"
-acceptance = """
-- When Perimeter selected: show Climb Cut checkbox, Number of Passes input
-- Parameters included in JSON config when present
-- Hidden for non-perimeter strategies
-"""
-deps = ["task-014"]
-status = "complete"
-
-[[tasks]]
-id = "task-017"
-title = "Update preview for 3D toolpaths"
-acceptance = """
-- preview_stl returns toolpath moves, not just contours
-- Canvas draws tool motion with color gradient by Z height
-- Zigzag paths visible as raster lines
-"""
-deps = ["task-009", "task-013"]
-status = "complete"
+spec_file = "specs/task-013.md"

--- a/design.md
+++ b/design.md
@@ -1,94 +1,136 @@
-# RustCAM Design: 3D Surface Machining
+# RustCAM Design: CAD/CAM MVP with Machine Tool Profiles
+
+## Overview
+
+Browser-based CAD/CAM tool running entirely in WASM. Supports multiple machine types
+(CNC mill, laser cutter) through a profile system that adapts parameters, strategies,
+and G-code output per machine. Ports useful Rust code from the cnc-sender project.
 
 ## Functional Requirements
 
-### FR-1: Custom Tool Definitions
-- [x] **FR-1.1**: Define `Tool` struct with type (end_mill, ball_end, face_mill), diameter, flute_length, corner_radius
-- [x] **FR-1.2**: Face mill tools support effective_diameter (cutting width) distinct from body diameter
-- [x] **FR-1.3**: Tool selection propagates to CutParams for strategy use
-- [x] **FR-1.4**: Web UI exposes tool type selection and relevant parameters
+### FR-1: Type-Safe Unit System (ported from cnc-sender)
+- [x] **FR-1.1**: Phantom-typed Distance<Mm>/Distance<Inch>, FeedRate<U>, SpindleSpeed
+- [x] **FR-1.2**: Compile-time prevention of unit mixing
+- [x] **FR-1.3**: Conversion methods between unit systems
 
-### FR-2: Zigzag 3D Surface Strategy
-- [x] **FR-2.1**: Implement `ZigzagSurfaceStrategy` that follows mesh surface height
-- [x] **FR-2.2**: Raster scan in X or Y direction with step_over spacing
-- [x] **FR-2.3**: Z-height derived from mesh triangle intersection at each XY point
-- [x] **FR-2.4**: Alternate row direction for continuous cutting (serpentine pattern)
-- [x] **FR-2.5**: Ball-end tool compensation: contact point offset based on local surface normal
+### FR-2: G-code Parser & Validator (ported from cnc-sender)
+- [x] **FR-2.1**: Parse G-code lines into structured GCodeCommand enum
+- [x] **FR-2.2**: Validate generated G-code against configurable machine limits
+- [x] **FR-2.3**: Support all common G/M codes (G0-G3, G20/21, G90/91, M3-M5, M7-M9)
 
-### FR-3: Perimeter Strategy
-- [x] **FR-3.1**: Implement `PerimeterStrategy` that follows outer boundary of mesh at each Z layer
-- [x] **FR-3.2**: Support climb vs conventional cut direction parameter
-- [x] **FR-3.3**: Tool radius compensation applied perpendicular to boundary
-- [x] **FR-3.4**: Multiple perimeter passes with step_over for finishing
+### FR-3: Machine Profile System
+- [x] **FR-3.1**: MachineType enum (CncMill, LaserCutter) with distinct capabilities
+- [x] **FR-3.2**: Profile defines available strategies, axis capabilities, power source
+- [x] **FR-3.3**: Default profiles with sensible parameters per machine type
+- [x] **FR-3.4**: JSON-serializable for WASM boundary passing
 
-### FR-4: Strategy Selection in UI
-- [x] **FR-4.1**: Add "Zigzag Surface" and "Perimeter" to strategy dropdown
-- [x] **FR-4.2**: Show/hide tool-type-specific parameters based on selection
-- [x] **FR-4.3**: Preview renders 3D toolpath projection to 2D canvas
+### FR-4: CNC Mill Profile
+- [x] **FR-4.1**: Wraps all existing functionality (spindle, Z-axis, all strategies)
+- [x] **FR-4.2**: Output: M3 spindle, Z-axis plunges, coolant control
+- [x] **FR-4.3**: Backward compatible - default behavior unchanged
 
-## Architecture Notes
+### FR-5: Laser Cutter Profile
+- [x] **FR-5.1**: Dynamic power mode (M4) with S-value power control
+- [x] **FR-5.2**: No Z-axis moves (2D only), S0 for rapid traversals
+- [x] **FR-5.3**: Supports contour (cut) and raster fill (engrave) strategies
+- [x] **FR-5.4**: Multi-pass cutting for thicker materials
 
-All new strategies implement `ToolpathStrategy` trait:
-```rust
-pub trait ToolpathStrategy {
-    fn generate(&self, contours: &[Polyline], params: &CutParams) -> Vec<Toolpath>;
-}
+### FR-6: Laser Cut Strategy
+- [x] **FR-6.1**: Follow 2D contour paths with configurable laser power
+- [x] **FR-6.2**: Multi-pass support (repeat path N times)
+- [x] **FR-6.3**: Lead-in overcut for clean edge closure
+
+### FR-7: Laser Engrave Strategy
+- [x] **FR-7.1**: Scanline raster fill of closed paths
+- [x] **FR-7.2**: Bidirectional serpentine scanning
+- [x] **FR-7.3**: Configurable line spacing (mm or DPI-derived)
+
+### FR-8: Profile-Aware G-code Emission
+- [x] **FR-8.1**: Preamble/postamble per machine profile
+- [x] **FR-8.2**: Rapid moves differ by profile (Z retract vs S0 power-off)
+- [x] **FR-8.3**: Correct M-codes per machine (M3 vs M4, coolant, etc.)
+
+### FR-9: WASM API Extensions
+- [x] **FR-9.1**: Config JSON accepts machine_type field (backward compatible)
+- [x] **FR-9.2**: available_profiles() export returns profile metadata
+- [x] **FR-9.3**: default_config(machine_type) export returns defaults
+
+### FR-10: Web UI Profile Integration
+- [x] **FR-10.1**: Machine type selector dynamically shows/hides parameters
+- [x] **FR-10.2**: Strategy dropdown filtered by profile capabilities
+- [x] **FR-10.3**: Canvas preview adapts to profile (Z-color vs power-color)
+
+## Architecture
+
+```
+                    ┌─────────────────┐
+                    │  MachineProfile  │
+                    │  (CNC/Laser/..)  │
+                    └────────┬────────┘
+                             │ configures
+    ┌────────────────────────┼────────────────────────┐
+    │                        │                        │
+    ▼                        ▼                        ▼
+┌─────────┐          ┌──────────────┐          ┌──────────┐
+│  Input   │          │  Strategies  │          │  Output  │
+│ STL/SVG  │───────►  │ (filtered by │───────►  │  G-code  │
+│ parsers  │          │  profile)    │          │ (profile │
+└─────────┘          └──────────────┘          │  aware)  │
+                                               └──────────┘
 ```
 
-For 3D surface strategies, extend `CutParams` or create `SurfaceParams` with mesh reference.
-
-## Non-Goals (Out of Scope)
-- Multi-tool operations in single job
-- Trochoidal or adaptive clearing (future work)
-- 5-axis toolpaths
-- Rest machining / stock model tracking
+### Source Files from cnc-sender to Port
+- `cnc-types/src/units.rs` → `src/units.rs` (phantom type units)
+- `cnc-gcode/src/parser.rs` → `src/gcode_parser.rs` (G-code parsing)
+- `cnc-gcode/src/validator.rs` → `src/gcode_validator.rs` (validation)
 
 ## Implementation Checklist
 
-### Foundation
-- [x] task-001: Define Tool struct with geometry types → FR-1.1, FR-1.2
-- [x] task-002: Extend CutParams to include Tool reference → FR-1.3
-- [x] task-003: Add tool type to CamConfig JSON schema → FR-1.3
+### Phase 1: Foundation (parallel)
+- [x] task-001: Port type-safe unit system from cnc-sender → FR-1
+- [x] task-002: Port G-code parser and validator → FR-2
+- [x] task-003: Define MachineProfile and MachineType → FR-3
 
-### 3D Surface Utilities
-- [x] task-004: Implement mesh height query at XY point → FR-2.3
-- [x] task-005: Implement surface normal at XY point → FR-2.5
+### Phase 2: Profiles (parallel after Phase 1)
+- [x] task-004: CNC mill profile wrapping existing behavior → FR-4
+- [x] task-005: Laser cutter profile → FR-5
 
-### Zigzag Surface Strategy
-- [x] task-006: Create SurfaceParams struct for 3D strategies → FR-2.1
-- [x] task-007: Implement ZigzagSurfaceStrategy core loop → FR-2.1, FR-2.2, FR-2.4
-- [x] task-008: Add ball-end tool compensation to zigzag → FR-2.5
-- [x] task-009: Wire ZigzagSurfaceStrategy into process_stl → FR-2.1
+### Phase 3: Strategies & Emitter (parallel after Phase 2)
+- [x] task-006: Profile-aware G-code emitter → FR-8
+- [x] task-007: Laser cut strategy → FR-6
+- [x] task-008: Laser engrave strategy → FR-7
 
-### Perimeter Strategy
-- [x] task-010: Implement PerimeterStrategy basic boundary follow → FR-3.1
-- [x] task-011: Add climb/conventional cut direction parameter → FR-3.2
-- [x] task-012: Support multiple perimeter passes → FR-3.4
-- [x] task-013: Wire PerimeterStrategy into process_stl → FR-3.1, FR-3.3
+### Phase 4: WASM API
+- [x] task-009: WASM API profile selection → FR-9
 
-### Web UI Updates
-- [x] task-014: Add strategy options to UI dropdown → FR-4.1
-- [x] task-015: Add tool type selector to UI → FR-1.4
-- [x] task-016: Add perimeter-specific parameters to UI → FR-4.2
-- [x] task-017: Update preview for 3D toolpaths → FR-4.3
+### Phase 5: UI & Testing (parallel after Phase 4)
+- [x] task-010: Web UI profile selector → FR-10
+- [x] task-011: Profile-aware canvas preview → FR-10.3
+- [x] task-012: End-to-end integration tests
+
+### Phase 6: Validation
+- [x] task-013: Post-generation G-code validation → FR-2.2
 
 ## Traceability Matrix
 
 | Requirement | Tasks |
 |-------------|-------|
-| FR-1.1 | task-001 |
-| FR-1.2 | task-001 |
-| FR-1.3 | task-002, task-003 |
-| FR-1.4 | task-015 |
-| FR-2.1 | task-006, task-007, task-009 |
-| FR-2.2 | task-007 |
-| FR-2.3 | task-004 |
-| FR-2.4 | task-007 |
-| FR-2.5 | task-005, task-008 |
-| FR-3.1 | task-010, task-013 |
-| FR-3.2 | task-011 |
-| FR-3.3 | task-013 |
-| FR-3.4 | task-012 |
-| FR-4.1 | task-014 |
-| FR-4.2 | task-016 |
-| FR-4.3 | task-017 |
+| FR-1 (Units) | task-001 |
+| FR-2 (Parser) | task-002, task-013 |
+| FR-3 (Profiles) | task-003 |
+| FR-4 (CNC Mill) | task-004 |
+| FR-5 (Laser) | task-005 |
+| FR-6 (Laser Cut) | task-007 |
+| FR-7 (Laser Engrave) | task-008 |
+| FR-8 (G-code Emit) | task-006 |
+| FR-9 (WASM API) | task-009 |
+| FR-10 (UI) | task-010, task-011 |
+
+## Non-Goals (Out of Scope for MVP)
+- Plasma cutter profile (future: port cnc-plasma layer system)
+- Machine communication / serial connection (stays in cnc-sender)
+- DXF/STEP/3MF import formats
+- Image-to-raster engraving (grayscale bitmap input)
+- Multi-tool operations in single job
+- 5-axis toolpaths
+- Material database / feeds & speeds calculator

--- a/docs/superpowers/specs/2026-03-18-nodi-style-node-editor-design.md
+++ b/docs/superpowers/specs/2026-03-18-nodi-style-node-editor-design.md
@@ -1,0 +1,268 @@
+# Nodi-Style DOM/SVG Node Editor for Dataflow Simulator
+
+## Problem
+
+The current dataflow editor (`www/src/dataflow/editor.ts`) renders everything on a single HTML Canvas. This prevents pan/zoom, makes hit-testing manual, can't leverage native DOM events for ports, and scales poorly as graphs grow. The nodi3d/nodi project demonstrates a better approach: DOM elements for nodes, SVG paths for connections, CSS transforms for pan/zoom.
+
+## Goal
+
+Replace the canvas-based editor with a DOM/SVG hybrid that follows nodi's rendering architecture while keeping the existing Rust WASM backend and `DataflowManager` completely unchanged.
+
+## What Changes
+
+| Layer | Current (canvas) | New (DOM/SVG) |
+|-------|-----------------|---------------|
+| Nodes | Canvas roundRect + fillText | `<div>` elements with CSS |
+| Connections | Canvas bezierCurveTo | SVG `<path>` cubic Beziers |
+| Ports | Canvas arc + manual hit-test | `<div>` elements with native events |
+| Pan/zoom | None | CSS `transform: translate() scale()` on container |
+| Grid | None | CSS background-image repeating pattern |
+| Selection | Manual coordinate check | DOM class toggle + native events |
+| Palette | DOM overlay hack | Searchable DOM dropdown |
+| Block info | External sidebar | Keep sidebar (unchanged) |
+
+## What Does NOT Change
+
+- `src/dataflow/` (Rust backend) — untouched
+- `www/src/dataflow/graph.ts` (`DataflowManager`) — untouched
+- `www/src/dataflow/types.ts` — untouched
+- `www/src/dataflow/plot.ts` — untouched
+- `www/src/dataflow/index.ts` — minor: swap `DataflowEditor` constructor (canvas → container div)
+- WASM API surface (`dataflow_*` exports) — untouched
+- Block types, scheduler, channels — untouched
+
+## Architecture
+
+### Coordinate Systems
+
+Two coordinate spaces are used throughout:
+
+- **Screen space**: pixel coordinates relative to the viewport (`clientX`, `clientY`)
+- **World space**: logical coordinates in the graph, independent of pan/zoom
+
+Conversion formulas:
+
+```
+worldX = (screenX - rect.left - panX) / scale
+worldY = (screenY - rect.top - panY) / scale
+
+screenX = worldX * scale + panX + rect.left
+screenY = worldY * scale + panY + rect.top
+```
+
+All node positions and SVG path coordinates are in world space. The CSS transform `translate(panX, panY) scale(scale)` on the node-layer and edge-layer converts world to screen automatically. The palette is positioned in screen space (readable at any zoom level) but creates blocks in world space.
+
+### Container Structure
+
+```
+div.df-workspace                    ← receives wheel (zoom) and middle-mouse (pan)
+├── svg.df-edge-layer               ← BEHIND nodes (renders first, lower z-index)
+│   │                                  pointer-events: none on <svg>, auto on <path> if needed
+│   ├── path.df-edge[data-ch="0"]  ← one per channel
+│   └── path.df-edge.dragging      ← wire being dragged (dashed)
+├── div.df-node-layer               ← CSS transform: translate(panX, panY) scale(zoom)
+│   ├── div.df-node[data-id="1"]   ← one per block
+│   │   ├── div.df-node-header     ← title + type subtitle
+│   │   ├── div.df-port.input[0]   ← input port circle + label
+│   │   ├── div.df-port.output[0]  ← output port circle + value label
+│   │   └── ...
+│   └── div.df-node[data-id="2"]
+│       └── ...
+├── div.df-grid                     ← CSS background grid (lowest z-index via z-index: -1)
+└── div.df-palette                  ← positioned in screen space at click point, searchable
+```
+
+The SVG edge layer is a sibling **before** the node layer in DOM order, so nodes paint on top of edges. The SVG element has `pointer-events: none` to avoid intercepting clicks meant for nodes/ports. Both the node layer and SVG edge layer share the same CSS transform so nodes and wires stay aligned during pan/zoom.
+
+### File Structure
+
+Replace `editor.ts` (430 lines, single file) with:
+
+| File | Responsibility | Approx size |
+|------|---------------|-------------|
+| `editor.ts` | Workspace: container setup, pan/zoom, grid, orchestration, `onTick` wiring, `destroy()` | ~180 lines |
+| `node-view.ts` | Create/update/remove node DOM elements, drag handling, right-click delete | ~150 lines |
+| `edge-view.ts` | Create/update/remove SVG path elements, Bezier math | ~80 lines |
+| `port-view.ts` | Port circles, drag-to-connect interaction, screen↔world conversion for wire drag | ~120 lines |
+| `palette.ts` | Searchable block type picker with default configs per block type | ~100 lines |
+
+### Orchestration (`editor.ts`)
+
+The `DataflowEditor` class owns the workspace and coordinates sub-modules:
+
+- Constructor: creates container DOM structure, sets up pan/zoom listeners on `.df-workspace`
+- Sets `mgr.onTick` callback which triggers reconciliation
+- `reconcile(snap)`: delegates to `node-view` (add/remove/update nodes) and `edge-view` (update paths)
+- `destroy()`: removes all DOM elements, calls `removeEventListener` on workspace, clears `mgr.onTick`
+
+### Pan/Zoom
+
+Following nodi's approach:
+- **Pan**: Middle-mouse or Shift+left drag updates `panX`, `panY`
+- **Zoom**: Wheel event adjusts `scale` (clamped 0.2–3.0), focal point preserved under cursor
+- Applied via single CSS transform on node-layer and edge-layer: `translate(${panX}px, ${panY}px) scale(${scale})`
+- Grid background adjusts `background-position` and `background-size` to match
+
+### Node Rendering (`node-view.ts`)
+
+Each block becomes a `<div class="df-node">` with:
+- Position via CSS `transform: translate(x, y)` (world coordinates, container transform handles pan/zoom)
+- Selection state via `.selected` class (border highlight)
+- Title: block name in `<div class="df-node-header">`
+- Subtitle: block_type in `<span class="df-node-type">`
+- Ports rendered as child `<div class="df-port">` elements
+
+Node dimensions: 140px wide, height = 40 + max(inputs, outputs) * 20px (same as current).
+
+**Drag**: `mousedown` on node header starts drag. `mousemove` updates `mgr.positions` and applies CSS transform. `mouseup` ends drag and triggers edge update for connected wires.
+
+**Delete**: `contextmenu` on a node calls `mgr.removeBlock(nodeId)` directly (no menu, same as current behavior). Fires reconciliation to remove DOM element and connected edges.
+
+### Node Positions
+
+Node positions are stored in `mgr.positions` (`Map<number, NodePosition>` on DataflowManager — unchanged). On drag, `node-view.ts` writes to `mgr.positions` and applies the CSS transform. On reconciliation, new nodes read initial position from `mgr.positions` (set by `mgr.addBlock()`).
+
+### Port Rendering (`port-view.ts`)
+
+Each port is a `<div class="df-port input|output">`:
+- Colored circle via CSS `background-color` based on port kind (Float=#4f8cff, Bytes=#ff9800, Text=#55ff88, Series=#ff55aa)
+- Input ports: left side, label to the right
+- Output ports: right side, value label to the left
+- `mousedown` on port starts wire drag
+- `mouseup` on port completes connection
+
+**Port positions for edges**: Computed from node position + fixed offsets (same math as current canvas code: output port X = node.x + NODE_W, input port X = node.x, port Y = node.y + PORT_OFFSET_Y + portIndex * PORT_SPACING + PORT_SPACING/2). This avoids `getBoundingClientRect()` rounding issues and is the approach nodi uses.
+
+**Wire drag coordinates**: During drag, cursor screen coordinates are converted to world space using the formula in the Coordinate Systems section, then used as the SVG path endpoint.
+
+### Edge Rendering (`edge-view.ts`)
+
+Connections are SVG `<path>` elements in the shared `<svg>` overlay:
+- Cubic Bezier: `M x1,y1 C x1+cpX,y1 x2-cpX,y2 x2,y2`
+- `cpX = max(0.5 * |x2-x1|, min(|y2-y1|, 50))` (nodi's formula for balanced curves)
+- Stroke: 2px, port-kind color
+- Drag preview: dashed path from source port to cursor (world space)
+
+**Topology-aware updates**: Edge paths are only rebuilt when the channel list changes (add/remove connection) or when a node is dragged (connected edges recompute endpoints). During normal tick updates (60fps play mode), only output value labels on nodes are updated — edge paths are not touched. This avoids layout thrashing.
+
+### Palette (`palette.ts`)
+
+Double-click on empty space opens a searchable picker:
+- Text input at top filters block types by name (stops keyboard event propagation)
+- Grouped by category (Sources, Math, Sinks, I/O, Serde)
+- Positioned in screen space (readable at any zoom)
+- Click creates block at the world-space coordinates of the double-click
+- Escape or click-outside dismisses
+
+**Default configs per block type** (carried from current code):
+```
+constant:    { value: 1.0 }
+gain:        { op: 'Gain', param1: 1.0, param2: 0.0 }
+clamp:       { op: 'Clamp', param1: 0.0, param2: 100.0 }
+plot:        { max_samples: 500 }
+udp_source:  { address: '127.0.0.1:9000' }
+udp_sink:    { address: '127.0.0.1:9001' }
+```
+
+### Snapshot Data Shapes
+
+The `ChannelSnapshot` type from `types.ts` wraps IDs in newtype objects:
+
+```typescript
+interface ChannelSnapshot {
+  id: { 0: number };
+  from_block: { 0: number };  // access as ch.from_block[0]
+  from_port: number;
+  to_block: { 0: number };    // access as ch.to_block[0]
+  to_port: number;
+}
+```
+
+All edge rendering code must use `ch.from_block[0]` and `ch.to_block[0]` to extract the numeric block ID.
+
+### CSS
+
+All styles in a `<style>` block within `www/index.html` (following existing pattern). Dark theme matching current colors:
+
+```css
+.df-workspace { position: relative; overflow: hidden; background: #0f1117; }
+.df-grid { position: absolute; inset: 0; z-index: 0; pointer-events: none; }
+.df-edge-layer { position: absolute; inset: 0; z-index: 1; pointer-events: none; overflow: visible; }
+.df-node-layer { position: absolute; inset: 0; z-index: 2; }
+.df-node { position: absolute; width: 140px; background: #1a1d27; border: 1px solid #2a2d3a; border-radius: 6px; cursor: grab; user-select: none; }
+.df-node.selected { border-color: #4f8cff; border-width: 2px; }
+.df-port { position: absolute; width: 12px; height: 12px; border-radius: 50%; cursor: crosshair; }
+.df-palette { position: fixed; z-index: 100; }
+```
+
+## Data Flow
+
+```
+User interaction (DOM events on nodes/ports/workspace)
+    ↓
+editor.ts (pan/zoom transforms, delegates to sub-modules)
+    ↓
+node-view.ts (drag) / port-view.ts (wire drag) / palette.ts (add block)
+    ↓
+DataflowManager (graph.ts) — unchanged
+    ↓
+WASM dataflow_* calls — unchanged
+    ↓
+GraphSnapshot JSON returned
+    ↓
+editor.ts reconcile():
+  ├── node-view: add/remove/update node divs + output labels
+  └── edge-view: update SVG paths only if topology changed
+    ↓
+index.ts updates sidebar info + plots — unchanged
+```
+
+### Reconciliation
+
+On each snapshot update (from `mgr.onTick` or manual refresh):
+
+1. Compare `snap.blocks` IDs against existing `.df-node` elements by `data-id`
+2. Add DOM nodes for new blocks (read position from `mgr.positions`), remove DOM for deleted blocks
+3. Update output value labels on existing nodes (fast — just `textContent` changes)
+4. Compare `snap.channels` IDs against current edge set. Only rebuild SVG paths if channels added/removed.
+5. During node drag: update edge endpoints for connected channels only.
+
+This is a lightweight reconcile, not a virtual DOM. Block count is typically <50.
+
+## Interface Contract
+
+The new `DataflowEditor` keeps the same public API with one addition:
+
+```typescript
+class DataflowEditor {
+  constructor(container: HTMLDivElement, mgr: DataflowManager);
+  resize(): void;
+  updateSnapshot(): void;
+  destroy(): void;  // NEW: cleanup listeners and DOM
+  onSelect: ((blockId: number | null, snap: GraphSnapshot | null) => void) | null;
+}
+```
+
+Constructor takes a `<div>` container instead of `<canvas>`. The `index.ts` update: swap `$canvas('dataflow-canvas')` for `$('dataflow-canvas')` and change the HTML element from `<canvas>` to `<div>`. On reset, call `editor.destroy()` before creating a new editor.
+
+## Testing
+
+- All existing `cargo test` (142 tests) must still pass — backend untouched
+- Manual validation:
+  - Double-click → palette appears → type to filter → select block → node appears
+  - Drag output port to input port → wire connects → snapshot confirms channel
+  - Right-click node → node deleted → connected wires removed
+  - Middle-mouse drag → pan works, nodes and wires move together
+  - Scroll wheel → zoom works, focal point preserved under cursor
+  - Play/Pause → output values update in real time on node labels
+  - Batch run → plot updates
+  - Reset → old editor cleaned up, new editor works
+
+## Non-Goals
+
+- Node grouping (nodi feature, not needed for MVP)
+- Undo/redo
+- Graph serialization to file (future)
+- Custom node shapes or icons
+- Minimap
+- Click-to-select edges (edges have `pointer-events: none`)

--- a/www/esbuild.config.mjs
+++ b/www/esbuild.config.mjs
@@ -2,6 +2,17 @@ import * as esbuild from 'esbuild';
 
 const watch = process.argv.includes('--watch');
 
+// Rewrite all rustcam.js imports to the correct path relative to dist/
+const wasmExternalPlugin = {
+  name: 'wasm-external',
+  setup(build) {
+    build.onResolve({ filter: /rustcam\.js$/ }, () => ({
+      path: '../pkg/rustcam.js',
+      external: true,
+    }));
+  },
+};
+
 /** @type {esbuild.BuildOptions} */
 const shared = {
   bundle: true,
@@ -9,6 +20,7 @@ const shared = {
   sourcemap: true,
   target: 'es2022',
   logLevel: 'info',
+  plugins: [wasmExternalPlugin],
 };
 
 // Main app bundle
@@ -16,8 +28,6 @@ const appCtx = await esbuild.context({
   ...shared,
   entryPoints: ['src/main.ts'],
   outfile: 'dist/main.js',
-  // WASM is loaded at runtime, treat as external
-  external: ['../pkg/rustcam.js', '../../pkg/rustcam.js'],
 });
 
 // Web Worker bundle
@@ -25,7 +35,6 @@ const workerCtx = await esbuild.context({
   ...shared,
   entryPoints: ['src/worker.ts'],
   outfile: 'dist/worker.js',
-  external: ['../pkg/rustcam.js', '../../pkg/rustcam.js'],
 });
 
 if (watch) {

--- a/www/pkg/rustcam.d.ts
+++ b/www/pkg/rustcam.d.ts
@@ -1,52 +1,243 @@
-/** Type declarations for wasm-pack generated bindings (rustcam). */
+/* tslint:disable */
+/* eslint-disable */
 
-export default function init(): Promise<void>;
-export function process_stl(data: Uint8Array, config_json: string): string;
-export function process_svg(svg_text: string, config_json: string): string;
-export function process_stl_progress(
-  data: Uint8Array,
-  config_json: string,
-  on_progress: (completed: number, total: number) => void,
-): string;
-export function process_svg_progress(
-  svg_text: string,
-  config_json: string,
-  on_progress: (completed: number, total: number) => void,
-): string;
-export function preview_stl(data: Uint8Array, config_json: string): string;
-export function preview_svg(svg_text: string): string;
-export function sim_moves_stl(data: Uint8Array, config_json: string): string;
-export function sim_moves_svg(svg_text: string, config_json: string): string;
+/**
+ * Return JSON list of available machine profiles.
+ */
 export function available_profiles(): string;
+
+/**
+ * Add a block to a graph. Returns block id.
+ */
+export function dataflow_add_block(graph_id: number, block_type: string, config_json: string): number;
+
+/**
+ * Advance the graph by wall-clock elapsed seconds (realtime mode).
+ * Returns snapshot JSON.
+ */
+export function dataflow_advance(graph_id: number, elapsed: number): string;
+
+/**
+ * List available block types as JSON.
+ */
+export function dataflow_block_types(): string;
+
+/**
+ * Connect an output port to an input port. Returns channel id.
+ */
+export function dataflow_connect(graph_id: number, from_block: number, from_port: number, to_block: number, to_port: number): number;
+
+/**
+ * Destroy a dataflow graph.
+ */
+export function dataflow_destroy(graph_id: number): void;
+
+/**
+ * Disconnect a channel.
+ */
+export function dataflow_disconnect(graph_id: number, channel_id: number): void;
+
+/**
+ * Create a new dataflow graph. Returns its id.
+ */
+export function dataflow_new(dt: number): number;
+
+/**
+ * Remove a block from a graph.
+ */
+export function dataflow_remove_block(graph_id: number, block_id: number): void;
+
+/**
+ * Run a fixed number of ticks (non-realtime batch mode).
+ * Returns snapshot JSON.
+ */
+export function dataflow_run(graph_id: number, steps: number, dt: number): string;
+
+/**
+ * Set the simulation speed multiplier.
+ */
+export function dataflow_set_speed(graph_id: number, speed: number): void;
+
+/**
+ * Get a snapshot of the graph without ticking.
+ */
+export function dataflow_snapshot(graph_id: number): string;
+
+/**
+ * Return a default config JSON for the given machine type.
+ */
 export function default_config(machine_type: string): string;
 
-// Sketch actor API
-export function sketch_reset(): void;
-export function sketch_add_point(x: number, y: number): string;
+/**
+ * Return toolpath data as JSON (for the 2-D preview canvas).
+ * Returns toolpath moves with Z coordinates for 3D visualization.
+ */
+export function preview_stl(data: Uint8Array, config_json: string): string;
+
+/**
+ * Return toolpath data from SVG as JSON (for the 2-D preview canvas).
+ */
+export function preview_svg(svg_text: string): string;
+
+/**
+ * Process an STL file (binary bytes) and return G-code.
+ */
+export function process_stl(data: Uint8Array, config_json: string): string;
+
+/**
+ * Process an STL file with progress reporting.
+ * The callback receives (completed_layers, total_layers) after each layer.
+ */
+export function process_stl_progress(data: Uint8Array, config_json: string, on_progress: Function): string;
+
+/**
+ * Process an SVG string and return G-code.
+ */
+export function process_svg(svg_text: string, config_json: string): string;
+
+/**
+ * Process an SVG string with progress reporting.
+ * The callback receives (completed_layers, total_layers) after each layer.
+ */
+export function process_svg_progress(svg_text: string, config_json: string, on_progress: Function): string;
+
+/**
+ * Return flat move list as JSON for the tool simulation.
+ * Each move: `{ x, y, z, rapid }`.
+ */
+export function sim_moves_stl(data: Uint8Array, config_json: string): string;
+
+export function sim_moves_svg(svg_text: string, config_json: string): string;
+
+/**
+ * Add a constraint. `kind` is one of: "coincident", "distance",
+ * "horizontal", "vertical", "fixed", "angle", "radius",
+ * "perpendicular", "parallel", "midpoint", "equal_length", "symmetric".
+ *
+ * `ids` is a JSON array of point ids, `value` is the numeric parameter
+ * (distance, angle, radius, x, y — depends on constraint type).
+ * For "fixed", pass `value` as x and `value2` as y.
+ *
+ * Returns JSON `{"id": <u32>}`.
+ */
+export function sketch_add_constraint(kind: string, ids_json: string, value: number, value2: number): string;
+
+/**
+ * Add a fixed point. Returns JSON `{"id": <u32>}`.
+ */
 export function sketch_add_fixed_point(x: number, y: number): string;
+
+/**
+ * Add a free point. Returns JSON `{"id": <u32>}`.
+ */
+export function sketch_add_point(x: number, y: number): string;
+
+/**
+ * Move a point to new coordinates.
+ */
 export function sketch_move_point(id: number, x: number, y: number): void;
-export function sketch_remove_point(id: number): void;
-export function sketch_set_fixed(id: number, fixed: boolean): void;
-export function sketch_add_constraint(
-  kind: string,
-  ids_json: string,
-  value: number,
-  value2: number,
-): string;
-export function sketch_remove_constraint(id: number): void;
-export function sketch_solve(): string;
+
+/**
+ * Process queued messages and return snapshot JSON.
+ */
 export function sketch_pump(): string;
+
+/**
+ * Remove a constraint by id.
+ */
+export function sketch_remove_constraint(id: number): void;
+
+/**
+ * Remove a point and all its constraints.
+ */
+export function sketch_remove_point(id: number): void;
+
+/**
+ * Reset the sketch actor to a blank state.
+ */
+export function sketch_reset(): void;
+
+/**
+ * Set a point's fixed flag.
+ */
+export function sketch_set_fixed(id: number, fixed: boolean): void;
+
+/**
+ * Get current snapshot without solving (read-only query).
+ */
 export function sketch_snapshot(): string;
 
-// Dataflow simulator API
-export function dataflow_new(dt: number): number;
-export function dataflow_destroy(graph_id: number): void;
-export function dataflow_add_block(graph_id: number, block_type: string, config_json: string): number;
-export function dataflow_remove_block(graph_id: number, block_id: number): void;
-export function dataflow_connect(graph_id: number, from_block: number, from_port: number, to_block: number, to_port: number): number;
-export function dataflow_disconnect(graph_id: number, channel_id: number): void;
-export function dataflow_advance(graph_id: number, elapsed: number): string;
-export function dataflow_run(graph_id: number, steps: number, dt: number): string;
-export function dataflow_set_speed(graph_id: number, speed: number): void;
-export function dataflow_snapshot(graph_id: number): string;
-export function dataflow_block_types(): string;
+/**
+ * Run the constraint solver and return a full snapshot as JSON.
+ * The snapshot includes points, constraints, DOF, solve status,
+ * and per-point coloring status.
+ */
+export function sketch_solve(): string;
+
+export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;
+
+export interface InitOutput {
+    readonly memory: WebAssembly.Memory;
+    readonly available_profiles: () => [number, number];
+    readonly dataflow_add_block: (a: number, b: number, c: number, d: number, e: number) => [number, number, number];
+    readonly dataflow_advance: (a: number, b: number) => [number, number, number, number];
+    readonly dataflow_block_types: () => [number, number];
+    readonly dataflow_connect: (a: number, b: number, c: number, d: number, e: number) => [number, number, number];
+    readonly dataflow_destroy: (a: number) => void;
+    readonly dataflow_disconnect: (a: number, b: number) => [number, number];
+    readonly dataflow_new: (a: number) => number;
+    readonly dataflow_remove_block: (a: number, b: number) => [number, number];
+    readonly dataflow_run: (a: number, b: number, c: number) => [number, number, number, number];
+    readonly dataflow_set_speed: (a: number, b: number) => [number, number];
+    readonly dataflow_snapshot: (a: number) => [number, number, number, number];
+    readonly default_config: (a: number, b: number) => [number, number];
+    readonly preview_stl: (a: number, b: number, c: number, d: number) => [number, number, number, number];
+    readonly preview_svg: (a: number, b: number) => [number, number, number, number];
+    readonly process_stl: (a: number, b: number, c: number, d: number) => [number, number, number, number];
+    readonly process_stl_progress: (a: number, b: number, c: number, d: number, e: any) => [number, number, number, number];
+    readonly process_svg: (a: number, b: number, c: number, d: number) => [number, number, number, number];
+    readonly process_svg_progress: (a: number, b: number, c: number, d: number, e: any) => [number, number, number, number];
+    readonly sim_moves_stl: (a: number, b: number, c: number, d: number) => [number, number, number, number];
+    readonly sim_moves_svg: (a: number, b: number, c: number, d: number) => [number, number, number, number];
+    readonly sketch_add_constraint: (a: number, b: number, c: number, d: number, e: number, f: number) => [number, number, number, number];
+    readonly sketch_add_fixed_point: (a: number, b: number) => [number, number];
+    readonly sketch_add_point: (a: number, b: number) => [number, number];
+    readonly sketch_move_point: (a: number, b: number, c: number) => void;
+    readonly sketch_pump: () => [number, number, number, number];
+    readonly sketch_remove_constraint: (a: number) => void;
+    readonly sketch_remove_point: (a: number) => void;
+    readonly sketch_reset: () => void;
+    readonly sketch_set_fixed: (a: number, b: number) => void;
+    readonly sketch_snapshot: () => [number, number, number, number];
+    readonly sketch_solve: () => [number, number, number, number];
+    readonly __wbindgen_exn_store: (a: number) => void;
+    readonly __externref_table_alloc: () => number;
+    readonly __wbindgen_externrefs: WebAssembly.Table;
+    readonly __wbindgen_free: (a: number, b: number, c: number) => void;
+    readonly __wbindgen_malloc: (a: number, b: number) => number;
+    readonly __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number;
+    readonly __externref_table_dealloc: (a: number) => void;
+    readonly __wbindgen_start: () => void;
+}
+
+export type SyncInitInput = BufferSource | WebAssembly.Module;
+
+/**
+ * Instantiates the given `module`, which can either be bytes or
+ * a precompiled `WebAssembly.Module`.
+ *
+ * @param {{ module: SyncInitInput }} module - Passing `SyncInitInput` directly is deprecated.
+ *
+ * @returns {InitOutput}
+ */
+export function initSync(module: { module: SyncInitInput } | SyncInitInput): InitOutput;
+
+/**
+ * If `module_or_path` is {RequestInfo} or {URL}, makes a request and
+ * for everything else, calls `WebAssembly.instantiate` directly.
+ *
+ * @param {{ module_or_path: InitInput | Promise<InitInput> }} module_or_path - Passing `InitInput` directly is deprecated.
+ *
+ * @returns {Promise<InitOutput>}
+ */
+export default function __wbg_init (module_or_path?: { module_or_path: InitInput | Promise<InitInput> } | InitInput | Promise<InitInput>): Promise<InitOutput>;


### PR DESCRIPTION
## Summary
- Complete CAD/CAM MVP with CNC mill and laser cutter machine profiles
- Ported type-safe units, G-code parser/validator from cnc-sender
- Laser cut (contour with power) and laser engrave (scanline raster fill) strategies
- Profile-aware G-code emission (M3/Z-retract for CNC, M4/S-value for laser)
- WASM API: `available_profiles()`, `default_config()`, profile-aware processing
- Web UI: machine type selector with dynamic parameter show/hide, strategy filtering, laser preview

## Test plan
- [x] 142 unit/integration tests pass (`cargo test`)
- [x] 0 clippy warnings
- [x] WASM build succeeds (`wasm-pack build`)
- [x] All 30 FR checkboxes validated against implementation
- [ ] Manual: load SVG, switch to Laser Cutter, generate G-code with M4/S values
- [ ] Manual: verify CNC Mill default behavior unchanged