### PR TITLE
Add PR preview deploys to gh-pages/pr/<number>/

### DIFF
--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -1,0 +1,28 @@
+name: PR Preview Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Remove preview folder for PR ${{ github.event.pull_request.number }}
+        run: |
+          if [ -d "pr/${{ github.event.pull_request.number }}" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git rm -rf "pr/${{ github.event.pull_request.number }}"
+            git commit -m "Clean up preview for PR #${{ github.event.pull_request.number }}"
+            git push
+          else
+            echo "No preview folder found, nothing to clean up."
+          fi

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,47 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: jetli/wasm-pack-action@v0.4.0
+
+      - run: cargo test --all
+
+      - run: wasm-pack build --target web --out-dir www/pkg --release
+
+      # Deploy into a pr/<number>/ subfolder on gh-pages so the
+      # production root is never touched by PR builds.
+      - name: Deploy preview to gh-pages/pr/${{ github.event.pull_request.number }}
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./www
+          destination_dir: pr/${{ github.event.pull_request.number }}
+          # Keep the rest of gh-pages intact (other PR previews + production root)
+          keep_files: true
+
+      - name: Post preview link on PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-preview
+          message: |
+            ### Preview deploy ready
+
+            **[Open preview](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr/${{ github.event.pull_request.number }}/)**
+
+            Built from ${{ github.sha }} — push again to update.


### PR DESCRIPTION
Each pull request now gets its own live preview deployed to a subfolder on gh-pages. Reviewers get a sticky comment with a direct link to test the WASM app before approving. Production root is never touched by PR builds.

Three workflow changes:
- pr-preview.yml: builds WASM on every PR push, deploys to gh-pages/pr/<number>/, posts a clickable preview link as a sticky comment on the PR
- pr-preview-cleanup.yml: removes the preview folder when the PR is closed (merged or abandoned)
- ci.yml: switch main deploy from the Pages API (deploy-pages) to peaceiris/actions-gh-pages with keep_files so production deploys preserve the pr/ preview folders; scope concurrency per-ref so main and PR builds don't cancel each other

https://claude.ai/code/session_01MrU8uY6HrXqBVg8vD2VHPe