### PR TITLE
refactor: eliminate block-specific models, add data-driven FunctionDef system

### DIFF
--- a/crates/rustsim/src/dataflow/blocks/constant.rs
+++ b/crates/rustsim/src/dataflow/blocks/constant.rs
@@ -56,6 +56,7 @@ impl Tick for ConstantBlock {
     }
 }
 
+#[allow(dead_code)]
 pub(crate) fn register(reg: &mut Vec<super::registry::BlockRegistration>) {
     reg.push(super::registry::BlockRegistration {
         block_type: "constant",

--- a/crates/rustsim/src/dataflow/blocks/data_driven.rs
+++ b/crates/rustsim/src/dataflow/blocks/data_driven.rs
@@ -1,0 +1,492 @@
+//! Data-driven block: a single generic block type parameterized by [`FunctionDef`].
+//!
+//! Replaces per-block Rust structs (ConstantBlock, FunctionBlock, PlotBlock, etc.)
+//! with a single implementation that reads its behaviour from a [`FunctionDef`]
+//! and a JSON config.  This eliminates block-specific model code from WASM and
+//! lets the frontend derive all schema, naming, and UI from the registry.
+
+use std::collections::HashMap;
+
+use module_traits::function_def::{FunctionDef, FunctionOp};
+use module_traits::value::{PortDef, Value};
+use module_traits::{Module, Tick};
+
+/// A block instance driven by a [`FunctionDef`] + runtime config values.
+pub struct DataDrivenBlock {
+    def: FunctionDef,
+    /// Runtime parameter values parsed from config JSON.
+    params: HashMap<String, f64>,
+    /// String parameter values (for topics, channel names, etc.).
+    string_params: HashMap<String, String>,
+    /// Internal state (plot buffer, pubsub last value, etc.).
+    state: BlockState,
+}
+
+/// Minimal internal state — only what's needed for simulation.
+/// Hardware-specific state lives in the BSP/channel layer, not here.
+enum BlockState {
+    None,
+    /// Plot accumulator buffer.
+    PlotBuffer { buffer: Vec<f64>, max_samples: usize },
+    /// PubSub source: holds current value until overwritten.
+    PubSubSource { current: Option<Value> },
+    /// PubSub sink: holds last received value.
+    PubSubSink { last: Option<Value> },
+}
+
+impl DataDrivenBlock {
+    /// Create a new block from a function definition and JSON config.
+    pub fn new(def: FunctionDef, config_json: &str) -> Result<Self, String> {
+        let config: serde_json::Value = serde_json::from_str(config_json)
+            .map_err(|e| format!("invalid config JSON for {}: {e}", def.id))?;
+
+        let mut params = HashMap::new();
+        let mut string_params = HashMap::new();
+
+        // Extract parameter values from config, falling back to defaults.
+        for p in &def.params {
+            match p.kind {
+                module_traits::function_def::ParamKind::Float => {
+                    let val = config
+                        .get(&p.name)
+                        .and_then(|v| v.as_f64())
+                        .unwrap_or_else(|| p.default.parse::<f64>().unwrap_or(0.0));
+                    params.insert(p.name.clone(), val);
+                }
+                module_traits::function_def::ParamKind::Int => {
+                    let val = config
+                        .get(&p.name)
+                        .and_then(|v| v.as_i64())
+                        .unwrap_or_else(|| p.default.parse::<i64>().unwrap_or(0))
+                        as f64;
+                    params.insert(p.name.clone(), val);
+                }
+                module_traits::function_def::ParamKind::String => {
+                    let val = config
+                        .get(&p.name)
+                        .and_then(|v| v.as_str())
+                        .unwrap_or(&p.default)
+                        .to_string();
+                    string_params.insert(p.name.clone(), val);
+                }
+                module_traits::function_def::ParamKind::Bool => {
+                    let val = config
+                        .get(&p.name)
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or_else(|| p.default == "true");
+                    params.insert(p.name.clone(), if val { 1.0 } else { 0.0 });
+                }
+            }
+        }
+
+        // Legacy config support: map old field names to new param names.
+        // These override defaults when the old keys are present in the config.
+        if def.op == FunctionOp::Gain {
+            if let Some(v) = config.get("param1").and_then(|v| v.as_f64()) {
+                params.insert("gain".into(), v);
+            }
+        }
+        if def.op == FunctionOp::Clamp {
+            if let Some(v) = config.get("param1").and_then(|v| v.as_f64()) {
+                params.insert("min".into(), v);
+            }
+            if let Some(v) = config.get("param2").and_then(|v| v.as_f64()) {
+                params.insert("max".into(), v);
+            }
+        }
+
+        // Legacy: map "port_kind" string to string_params for pubsub
+        if matches!(def.op, FunctionOp::PubSubSource | FunctionOp::PubSubSink) {
+            if !string_params.contains_key("topic") {
+                if let Some(t) = config.get("topic").and_then(|v| v.as_str()) {
+                    string_params.insert("topic".into(), t.to_string());
+                }
+            }
+            if !string_params.contains_key("port_kind") {
+                if let Some(pk) = config.get("port_kind").and_then(|v| v.as_str()) {
+                    string_params.insert("port_kind".into(), pk.to_string());
+                }
+            }
+        }
+
+        let state = match def.op {
+            FunctionOp::PlotAccum => {
+                let max = params.get("max_samples").copied().unwrap_or(500.0) as usize;
+                BlockState::PlotBuffer {
+                    buffer: Vec::new(),
+                    max_samples: max,
+                }
+            }
+            FunctionOp::PubSubSource => BlockState::PubSubSource { current: None },
+            FunctionOp::PubSubSink => BlockState::PubSubSink { last: None },
+            _ => BlockState::None,
+        };
+
+        Ok(Self {
+            def,
+            params,
+            string_params,
+            state,
+        })
+    }
+
+    fn param_f64(&self, name: &str) -> f64 {
+        self.params.get(name).copied().unwrap_or(0.0)
+    }
+}
+
+impl Module for DataDrivenBlock {
+    fn name(&self) -> &str {
+        &self.def.display_name
+    }
+
+    fn block_type(&self) -> &str {
+        &self.def.id
+    }
+
+    fn input_ports(&self) -> Vec<PortDef> {
+        self.def
+            .inputs
+            .iter()
+            .map(|p| PortDef::new(&p.name, p.kind.clone()))
+            .collect()
+    }
+
+    fn output_ports(&self) -> Vec<PortDef> {
+        self.def
+            .outputs
+            .iter()
+            .map(|p| PortDef::new(&p.name, p.kind.clone()))
+            .collect()
+    }
+
+    fn config_json(&self) -> String {
+        let mut map = serde_json::Map::new();
+        for (k, v) in &self.params {
+            map.insert(k.clone(), serde_json::Value::from(*v));
+        }
+        for (k, v) in &self.string_params {
+            map.insert(k.clone(), serde_json::Value::from(v.clone()));
+        }
+        serde_json::to_string(&map).unwrap_or_else(|_| "{}".to_string())
+    }
+
+    fn as_tick(&mut self) -> Option<&mut dyn Tick> {
+        Some(self)
+    }
+}
+
+impl Tick for DataDrivenBlock {
+    fn tick(&mut self, inputs: &[Option<&Value>], _dt: f64) -> Vec<Option<Value>> {
+        match self.def.op {
+            FunctionOp::Constant => {
+                vec![Some(Value::Float(self.param_f64("value")))]
+            }
+            FunctionOp::Gain => {
+                let v = inputs.first().and_then(|i| i.and_then(|v| v.as_float()));
+                vec![v.map(|x| Value::Float(x * self.param_f64("gain")))]
+            }
+            FunctionOp::Add => {
+                let a = inputs.first().and_then(|i| i.and_then(|v| v.as_float()));
+                let b = inputs.get(1).and_then(|i| i.and_then(|v| v.as_float()));
+                let result = match (a, b) {
+                    (Some(a), Some(b)) => Some(a + b),
+                    (Some(a), None) => Some(a),
+                    (None, Some(b)) => Some(b),
+                    (None, None) => None,
+                };
+                vec![result.map(Value::Float)]
+            }
+            FunctionOp::Multiply => {
+                let a = inputs.first().and_then(|i| i.and_then(|v| v.as_float()));
+                let b = inputs.get(1).and_then(|i| i.and_then(|v| v.as_float()));
+                vec![match (a, b) {
+                    (Some(a), Some(b)) => Some(Value::Float(a * b)),
+                    _ => None,
+                }]
+            }
+            FunctionOp::Subtract => {
+                let a = inputs.first().and_then(|i| i.and_then(|v| v.as_float()));
+                let b = inputs.get(1).and_then(|i| i.and_then(|v| v.as_float()));
+                vec![match (a, b) {
+                    (Some(a), Some(b)) => Some(Value::Float(a - b)),
+                    _ => None,
+                }]
+            }
+            FunctionOp::Clamp => {
+                let v = inputs.first().and_then(|i| i.and_then(|v| v.as_float()));
+                let min = self.param_f64("min");
+                let max = self.param_f64("max");
+                vec![v.map(|x| Value::Float(x.clamp(min, max)))]
+            }
+            FunctionOp::Select => {
+                let cond = inputs.first().and_then(|i| i.and_then(|v| v.as_float()));
+                let a = inputs.get(1).and_then(|i| i.and_then(|v| v.as_float()));
+                let b = inputs.get(2).and_then(|i| i.and_then(|v| v.as_float()));
+                let result = match (cond, a, b) {
+                    (Some(c), Some(a), Some(b)) => {
+                        Some(Value::Float(if c > 0.0 { a } else { b }))
+                    }
+                    _ => None,
+                };
+                vec![result]
+            }
+            FunctionOp::ChannelRead => {
+                // In WASM, channel reads return 0.0 (no hardware).
+                // Real values come from BSP-bound typed channels at deploy time.
+                vec![Some(Value::Float(0.0))]
+            }
+            FunctionOp::ChannelWrite => {
+                // In WASM, channel writes are no-ops.
+                vec![]
+            }
+            FunctionOp::PlotAccum => {
+                if let BlockState::PlotBuffer {
+                    ref mut buffer,
+                    max_samples,
+                } = self.state
+                {
+                    if let Some(v) =
+                        inputs.first().and_then(|i| i.and_then(|v| v.as_float()))
+                    {
+                        buffer.push(v);
+                        if buffer.len() > max_samples {
+                            buffer.remove(0);
+                        }
+                    }
+                    vec![Some(Value::Series(buffer.clone()))]
+                } else {
+                    vec![None]
+                }
+            }
+            FunctionOp::JsonEncode => {
+                let out = inputs
+                    .first()
+                    .and_then(|i| *i)
+                    .and_then(|v| serde_json::to_string(v).ok())
+                    .map(Value::Text);
+                vec![out]
+            }
+            FunctionOp::JsonDecode => {
+                let out = inputs
+                    .first()
+                    .and_then(|i| i.and_then(|v| v.as_text()))
+                    .and_then(|text| serde_json::from_str::<Value>(text).ok());
+                vec![out]
+            }
+            FunctionOp::PubSubSource => {
+                if let BlockState::PubSubSource { ref current } = self.state {
+                    vec![current.clone()]
+                } else {
+                    vec![None]
+                }
+            }
+            FunctionOp::PubSubSink => {
+                if let BlockState::PubSubSink { ref mut last } = self.state {
+                    *last = inputs.first().and_then(|v| v.cloned());
+                }
+                vec![]
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use module_traits::function_def::builtin_function_defs;
+
+    fn find_def(id: &str) -> FunctionDef {
+        builtin_function_defs()
+            .into_iter()
+            .find(|d| d.id == id)
+            .unwrap()
+    }
+
+    #[test]
+    fn constant_block() {
+        let def = find_def("constant");
+        let mut b = DataDrivenBlock::new(def, r#"{"value": 42.0}"#).unwrap();
+        let out = b.tick(&[], 0.01);
+        assert_eq!(out[0].as_ref().unwrap().as_float(), Some(42.0));
+    }
+
+    #[test]
+    fn constant_legacy_config() {
+        let def = find_def("constant");
+        let mut b = DataDrivenBlock::new(def, r#"{"value": 5.0}"#).unwrap();
+        assert_eq!(b.name(), "Constant");
+        assert_eq!(b.block_type(), "constant");
+        let out = b.tick(&[], 0.01);
+        assert_eq!(out[0].as_ref().unwrap().as_float(), Some(5.0));
+    }
+
+    #[test]
+    fn gain_block() {
+        let def = find_def("gain");
+        let mut b = DataDrivenBlock::new(def, r#"{"gain": 3.0}"#).unwrap();
+        let input = Value::Float(4.0);
+        let out = b.tick(&[Some(&input)], 0.01);
+        assert_eq!(out[0].as_ref().unwrap().as_float(), Some(12.0));
+    }
+
+    #[test]
+    fn gain_legacy_param1() {
+        let def = find_def("gain");
+        let mut b =
+            DataDrivenBlock::new(def, r#"{"op":"Gain","param1":2.0}"#).unwrap();
+        let input = Value::Float(5.0);
+        let out = b.tick(&[Some(&input)], 0.01);
+        assert_eq!(out[0].as_ref().unwrap().as_float(), Some(10.0));
+    }
+
+    #[test]
+    fn add_block() {
+        let def = find_def("add");
+        let mut b = DataDrivenBlock::new(def, "{}").unwrap();
+        let a = Value::Float(2.0);
+        let bv = Value::Float(3.0);
+        let out = b.tick(&[Some(&a), Some(&bv)], 0.01);
+        assert_eq!(out[0].as_ref().unwrap().as_float(), Some(5.0));
+    }
+
+    #[test]
+    fn multiply_block() {
+        let def = find_def("multiply");
+        let mut b = DataDrivenBlock::new(def, "{}").unwrap();
+        let a = Value::Float(3.0);
+        let bv = Value::Float(4.0);
+        let out = b.tick(&[Some(&a), Some(&bv)], 0.01);
+        assert_eq!(out[0].as_ref().unwrap().as_float(), Some(12.0));
+    }
+
+    #[test]
+    fn clamp_block() {
+        let def = find_def("clamp");
+        let mut b = DataDrivenBlock::new(def, r#"{"min": 0.0, "max": 10.0}"#).unwrap();
+        let input = Value::Float(15.0);
+        let out = b.tick(&[Some(&input)], 0.01);
+        assert_eq!(out[0].as_ref().unwrap().as_float(), Some(10.0));
+    }
+
+    #[test]
+    fn clamp_legacy_params() {
+        let def = find_def("clamp");
+        let mut b = DataDrivenBlock::new(
+            def,
+            r#"{"op":"Clamp","param1":0.0,"param2":1.0}"#,
+        )
+        .unwrap();
+        let input = Value::Float(0.5);
+        let out = b.tick(&[Some(&input)], 0.01);
+        assert_eq!(out[0].as_ref().unwrap().as_float(), Some(0.5));
+    }
+
+    #[test]
+    fn select_block() {
+        let def = find_def("select");
+        let mut b = DataDrivenBlock::new(def, "{}").unwrap();
+        let cond = Value::Float(1.0);
+        let a = Value::Float(10.0);
+        let bv = Value::Float(20.0);
+        let out = b.tick(&[Some(&cond), Some(&a), Some(&bv)], 0.01);
+        assert_eq!(out[0].as_ref().unwrap().as_float(), Some(10.0));
+
+        let cond_false = Value::Float(0.0);
+        let out2 = b.tick(&[Some(&cond_false), Some(&a), Some(&bv)], 0.01);
+        assert_eq!(out2[0].as_ref().unwrap().as_float(), Some(20.0));
+    }
+
+    #[test]
+    fn subtract_block() {
+        let def = find_def("subtract");
+        let mut b = DataDrivenBlock::new(def, "{}").unwrap();
+        let a = Value::Float(10.0);
+        let bv = Value::Float(3.0);
+        let out = b.tick(&[Some(&a), Some(&bv)], 0.01);
+        assert_eq!(out[0].as_ref().unwrap().as_float(), Some(7.0));
+    }
+
+    #[test]
+    fn plot_accumulates() {
+        let def = find_def("plot");
+        let mut b = DataDrivenBlock::new(def, r#"{"max_samples": 3}"#).unwrap();
+        for i in 0..5 {
+            let v = Value::Float(i as f64);
+            b.tick(&[Some(&v)], 0.01);
+        }
+        let out = b.tick(&[Some(&Value::Float(5.0))], 0.01);
+        let series = out[0].as_ref().unwrap().as_series().unwrap();
+        assert_eq!(series, &[3.0, 4.0, 5.0]);
+    }
+
+    #[test]
+    fn json_roundtrip() {
+        let enc_def = find_def("json_encode");
+        let dec_def = find_def("json_decode");
+        let mut enc = DataDrivenBlock::new(enc_def, "{}").unwrap();
+        let mut dec = DataDrivenBlock::new(dec_def, "{}").unwrap();
+
+        let input = Value::Float(1.234);
+        let encoded = enc.tick(&[Some(&input)], 0.01);
+        let text = encoded[0].as_ref().unwrap();
+        let decoded = dec.tick(&[Some(text)], 0.01);
+        assert_eq!(decoded[0].as_ref().unwrap().as_float(), Some(1.234));
+    }
+
+    #[test]
+    fn channel_read_returns_zero() {
+        let def = find_def("channel_read");
+        let mut b = DataDrivenBlock::new(def, r#"{"channel":"adc0"}"#).unwrap();
+        let out = b.tick(&[], 0.01);
+        assert_eq!(out[0].as_ref().unwrap().as_float(), Some(0.0));
+    }
+
+    #[test]
+    fn channel_write_is_noop() {
+        let def = find_def("channel_write");
+        let mut b = DataDrivenBlock::new(def, r#"{"channel":"pwm0"}"#).unwrap();
+        let out = b.tick(&[Some(&Value::Float(0.5))], 0.01);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn pubsub_source_and_sink() {
+        let src_def = find_def("pubsub_source");
+        let sink_def = find_def("pubsub_sink");
+        let mut src = DataDrivenBlock::new(src_def, r#"{"topic":"t","port_kind":"Float"}"#).unwrap();
+        let mut sink = DataDrivenBlock::new(sink_def, r#"{"topic":"t","port_kind":"Float"}"#).unwrap();
+
+        // Source initially empty
+        let out = src.tick(&[], 0.01);
+        assert_eq!(out[0], None);
+
+        // Sink stores value
+        let v = Value::Float(42.0);
+        let sink_out = sink.tick(&[Some(&v)], 0.01);
+        assert!(sink_out.is_empty());
+    }
+
+    #[test]
+    fn config_json_roundtrip() {
+        let def = find_def("gain");
+        let b = DataDrivenBlock::new(def, r#"{"gain": 2.5}"#).unwrap();
+        let json = b.config_json();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["gain"], 2.5);
+    }
+
+    #[test]
+    fn module_trait_accessors() {
+        let def = find_def("add");
+        let mut b = DataDrivenBlock::new(def, "{}").unwrap();
+        assert_eq!(b.name(), "Add");
+        assert_eq!(b.block_type(), "add");
+        assert_eq!(b.input_ports().len(), 2);
+        assert_eq!(b.output_ports().len(), 1);
+        assert!(b.as_tick().is_some());
+        assert!(b.as_analysis().is_none());
+        assert!(b.as_codegen().is_none());
+        assert!(b.as_sim_model().is_none());
+    }
+}

--- a/crates/rustsim/src/dataflow/blocks/function.rs
+++ b/crates/rustsim/src/dataflow/blocks/function.rs
@@ -157,6 +157,7 @@ impl Tick for FunctionBlock {
     }
 }
 
+#[allow(dead_code)]
 pub(crate) fn register(reg: &mut Vec<super::registry::BlockRegistration>) {
     reg.push(super::registry::BlockRegistration {
         block_type: "gain",

--- a/crates/rustsim/src/dataflow/blocks/mod.rs
+++ b/crates/rustsim/src/dataflow/blocks/mod.rs
@@ -285,15 +285,61 @@ mod tests {
         assert_eq!(block.block_type(), "tmc2209_stallguard");
     }
 
+    // ── New data-driven block creation tests ──────────────────────
+
+    #[test]
+    fn create_block_subtract() {
+        let block = create_block("subtract", "{}").unwrap();
+        assert_eq!(block.block_type(), "subtract");
+        assert_eq!(block.input_ports().len(), 2);
+        assert_eq!(block.output_ports().len(), 1);
+    }
+
+    #[test]
+    fn create_block_select() {
+        let block = create_block("select", "{}").unwrap();
+        assert_eq!(block.block_type(), "select");
+        assert_eq!(block.input_ports().len(), 3);
+        assert_eq!(block.output_ports().len(), 1);
+    }
+
+    #[test]
+    fn create_block_channel_read() {
+        let block = create_block("channel_read", r#"{"channel":"adc0"}"#).unwrap();
+        assert_eq!(block.block_type(), "channel_read");
+        assert_eq!(block.input_ports().len(), 0);
+        assert_eq!(block.output_ports().len(), 1);
+    }
+
+    #[test]
+    fn create_block_channel_write() {
+        let block = create_block("channel_write", r#"{"channel":"pwm0"}"#).unwrap();
+        assert_eq!(block.block_type(), "channel_write");
+        assert_eq!(block.input_ports().len(), 1);
+        assert_eq!(block.output_ports().len(), 0);
+    }
+
     #[test]
     fn create_block_invalid_json_errors() {
-        // Exercise all map_err closures by passing invalid JSON to each block type
+        // Exercise error paths by passing invalid JSON to each block type
         let bad = "not json";
         for bt in &[
+            // Data-driven blocks
             "constant",
             "gain",
+            "add",
+            "multiply",
+            "subtract",
             "clamp",
+            "select",
+            "channel_read",
+            "channel_write",
             "plot",
+            "json_encode",
+            "json_decode",
+            "pubsub_sink",
+            "pubsub_source",
+            // Legacy blocks
             "udp_source",
             "udp_sink",
             "adc_source",
@@ -303,8 +349,6 @@ mod tests {
             "uart_tx",
             "uart_rx",
             "state_machine",
-            "pubsub_sink",
-            "pubsub_source",
             "encoder",
             "ssd1306_display",
             "tmc2209_stepper",

--- a/crates/rustsim/src/dataflow/blocks/mod.rs
+++ b/crates/rustsim/src/dataflow/blocks/mod.rs
@@ -1,6 +1,12 @@
 //! Built-in block implementations.
+//!
+//! The primary creation path uses [`data_driven::DataDrivenBlock`] driven by
+//! [`module_traits::builtin_function_defs`].  Legacy per-struct blocks
+//! (embedded, state_machine, udp) are kept for features not yet expressible
+//! as pure `FunctionDef` values.
 
 pub mod constant;
+pub mod data_driven;
 pub mod embedded;
 pub mod function;
 pub mod plot;
@@ -12,24 +18,33 @@ pub mod udp;
 
 use self::registry::BlockRegistration;
 use super::block::Module;
+use module_traits::function_def::builtin_function_defs;
 
-/// Collect all block registrations from every block module.
-fn all_registrations() -> Vec<BlockRegistration> {
+/// Collect legacy block registrations (blocks not yet converted to data-driven).
+fn legacy_registrations() -> Vec<BlockRegistration> {
     let mut reg = Vec::new();
-    constant::register(&mut reg);
-    function::register(&mut reg);
-    plot::register(&mut reg);
-    serde_block::register(&mut reg);
-    udp::register(&mut reg);
+    // Only register block types that are NOT covered by FunctionDef.
+    // Legacy blocks: embedded peripherals (need SimModel), state_machine, udp
     embedded::register(&mut reg);
     state_machine::register(&mut reg);
-    pubsub::register(&mut reg);
+    udp::register(&mut reg);
     reg
 }
 
 /// Create a block from its type name and JSON config.
+///
+/// Tries the data-driven [`FunctionDef`] registry first, then falls back
+/// to legacy per-struct block registrations.
 pub fn create_block(block_type: &str, config_json: &str) -> Result<Box<dyn Module>, String> {
-    all_registrations()
+    // Try data-driven first
+    let defs = builtin_function_defs();
+    if let Some(def) = defs.into_iter().find(|d| d.id == block_type) {
+        return data_driven::DataDrivenBlock::new(def, config_json)
+            .map(|b| Box::new(b) as Box<dyn Module>);
+    }
+
+    // Fall back to legacy per-struct blocks
+    legacy_registrations()
         .iter()
         .find(|r| r.block_type == block_type)
         .map(|r| (r.create_from_json)(config_json))
@@ -37,15 +52,37 @@ pub fn create_block(block_type: &str, config_json: &str) -> Result<Box<dyn Modul
 }
 
 /// List all available block types for the palette.
+///
+/// Merges data-driven function defs with legacy block registrations.
 pub fn available_block_types() -> Vec<BlockTypeInfo> {
-    all_registrations()
+    let mut types: Vec<BlockTypeInfo> = builtin_function_defs()
         .iter()
-        .map(|r| BlockTypeInfo {
-            block_type: r.block_type,
-            name: r.display_name,
-            category: r.category,
+        .map(|d| BlockTypeInfo {
+            block_type: leak_str(&d.id),
+            name: leak_str(&d.display_name),
+            category: leak_str(&d.category),
         })
-        .collect()
+        .collect();
+
+    // Add legacy blocks that aren't covered by FunctionDef
+    let dd_ids: std::collections::HashSet<&str> = types.iter().map(|t| t.block_type).collect();
+    for r in legacy_registrations() {
+        if !dd_ids.contains(r.block_type) {
+            types.push(BlockTypeInfo {
+                block_type: r.block_type,
+                name: r.display_name,
+                category: r.category,
+            });
+        }
+    }
+
+    types
+}
+
+/// Leak a string to get a `&'static str` — only called at palette-build time
+/// (a small, bounded set of strings), not on every tick.
+fn leak_str(s: &str) -> &'static str {
+    Box::leak(s.to_string().into_boxed_str())
 }
 
 #[derive(Debug, serde::Serialize, tsify_next::Tsify)]

--- a/crates/rustsim/src/dataflow/blocks/plot.rs
+++ b/crates/rustsim/src/dataflow/blocks/plot.rs
@@ -75,6 +75,7 @@ impl Tick for PlotBlock {
     }
 }
 
+#[allow(dead_code)]
 pub(crate) fn register(reg: &mut Vec<super::registry::BlockRegistration>) {
     reg.push(super::registry::BlockRegistration {
         block_type: "plot",

--- a/crates/rustsim/src/dataflow/blocks/pubsub.rs
+++ b/crates/rustsim/src/dataflow/blocks/pubsub.rs
@@ -173,6 +173,7 @@ impl Tick for PubSubSourceBlock {
     }
 }
 
+#[allow(dead_code)]
 pub(crate) fn register(reg: &mut Vec<super::registry::BlockRegistration>) {
     reg.push(super::registry::BlockRegistration {
         block_type: "pubsub_sink",

--- a/crates/rustsim/src/dataflow/blocks/serde_block.rs
+++ b/crates/rustsim/src/dataflow/blocks/serde_block.rs
@@ -79,6 +79,7 @@ impl Tick for JsonDecodeBlock {
     }
 }
 
+#[allow(dead_code)]
 pub(crate) fn register(reg: &mut Vec<super::registry::BlockRegistration>) {
     reg.push(super::registry::BlockRegistration {
         block_type: "json_encode",

--- a/crates/rustsim/src/dataflow/codegen/mod.rs
+++ b/crates/rustsim/src/dataflow/codegen/mod.rs
@@ -15,8 +15,6 @@ pub mod types;
 
 #[cfg(feature = "mlir")]
 pub use emit::generate_workspace_mlir;
-#[cfg(feature = "mlir")]
-pub use emit::generate_workspace_mlir;
 pub use emit::{
     generate_distributed_workspace, generate_rust, generate_workspace, CodegenBackend,
     DistributedConfig, DistributedWorkspace, GeneratedCrate, GeneratedWorkspace, TransportConfig,

--- a/crates/rustsim/src/dataflow/graph.rs
+++ b/crates/rustsim/src/dataflow/graph.rs
@@ -616,6 +616,99 @@ mod tests {
         assert!(!g.simulation_mode);
     }
 
+    // ── Data-driven block integration tests ──────────────────────────
+
+    #[test]
+    fn data_driven_constant_via_create_block() {
+        use crate::dataflow::blocks::create_block;
+        let mut g = DataflowGraph::new();
+        let block = create_block("constant", r#"{"value": 7.0}"#).unwrap();
+        let c = g.add_block(block);
+        g.tick(0.01);
+        let snap = g.snapshot();
+        let b = snap.blocks.iter().find(|b| b.id == c.0).unwrap();
+        assert_eq!(b.output_values[0].as_ref().unwrap().as_float(), Some(7.0));
+    }
+
+    #[test]
+    fn data_driven_subtract_chain() {
+        use crate::dataflow::blocks::create_block;
+        let mut g = DataflowGraph::new();
+        let a = g.add_block(create_block("constant", r#"{"value": 10.0}"#).unwrap());
+        let b = g.add_block(create_block("constant", r#"{"value": 3.0}"#).unwrap());
+        let sub = g.add_block(create_block("subtract", "{}").unwrap());
+        g.connect(a, 0, sub, 0).unwrap();
+        g.connect(b, 0, sub, 1).unwrap();
+        g.tick(0.01);
+        g.tick(0.01);
+        let snap = g.snapshot();
+        let sub_snap = snap.blocks.iter().find(|b| b.id == sub.0).unwrap();
+        assert_eq!(
+            sub_snap.output_values[0].as_ref().unwrap().as_float(),
+            Some(7.0)
+        );
+    }
+
+    #[test]
+    fn data_driven_select_block() {
+        use crate::dataflow::blocks::create_block;
+        let mut g = DataflowGraph::new();
+        let cond = g.add_block(create_block("constant", r#"{"value": 1.0}"#).unwrap());
+        let a = g.add_block(create_block("constant", r#"{"value": 10.0}"#).unwrap());
+        let b = g.add_block(create_block("constant", r#"{"value": 20.0}"#).unwrap());
+        let sel = g.add_block(create_block("select", "{}").unwrap());
+        g.connect(cond, 0, sel, 0).unwrap();
+        g.connect(a, 0, sel, 1).unwrap();
+        g.connect(b, 0, sel, 2).unwrap();
+        g.tick(0.01);
+        g.tick(0.01);
+        let snap = g.snapshot();
+        let sel_snap = snap.blocks.iter().find(|b| b.id == sel.0).unwrap();
+        // cond > 0 → selects a (10.0)
+        assert_eq!(
+            sel_snap.output_values[0].as_ref().unwrap().as_float(),
+            Some(10.0)
+        );
+    }
+
+    #[test]
+    fn data_driven_channel_read_write() {
+        use crate::dataflow::blocks::create_block;
+        let mut g = DataflowGraph::new();
+        let cr = g.add_block(
+            create_block("channel_read", r#"{"channel": "adc0"}"#).unwrap(),
+        );
+        let cw = g.add_block(
+            create_block("channel_write", r#"{"channel": "pwm0"}"#).unwrap(),
+        );
+        g.connect(cr, 0, cw, 0).unwrap();
+        g.tick(0.01);
+        let snap = g.snapshot();
+        // channel_read returns 0.0 in WASM (no hardware)
+        let cr_snap = snap.blocks.iter().find(|b| b.id == cr.0).unwrap();
+        assert_eq!(
+            cr_snap.output_values[0].as_ref().unwrap().as_float(),
+            Some(0.0)
+        );
+        // channel_write is a sink — no outputs
+        let cw_snap = snap.blocks.iter().find(|b| b.id == cw.0).unwrap();
+        assert!(cw_snap.output_values.is_empty());
+    }
+
+    #[test]
+    fn data_driven_gain_new_schema() {
+        use crate::dataflow::blocks::create_block;
+        let mut g = DataflowGraph::new();
+        let c = g.add_block(create_block("constant", r#"{"value": 4.0}"#).unwrap());
+        let gain = g.add_block(create_block("gain", r#"{"gain": 3.0}"#).unwrap());
+        g.connect(c, 0, gain, 0).unwrap();
+        g.tick(0.01);
+        g.tick(0.01);
+        let snap = g.snapshot();
+        let gs = snap.blocks.iter().find(|b| b.id == gain.0).unwrap();
+        assert_eq!(gs.output_values[0].as_ref().unwrap().as_float(), Some(12.0));
+    }
+
     #[test]
     fn connect_errors() {
         let mut g = DataflowGraph::new();

--- a/crates/rustsim/src/lib.rs
+++ b/crates/rustsim/src/lib.rs
@@ -254,6 +254,61 @@ pub fn dataflow_block_types() -> JsValue {
     serde_wasm_bindgen::to_value(&types).unwrap_or(JsValue::NULL)
 }
 
+// ── Function Def Schema API ──────────────────────────────────────────
+
+/// Return the full function definition registry as JSON.
+///
+/// This is the single source of truth for all block types — the frontend
+/// uses this to build its palette, config panels, and validation instead
+/// of maintaining its own type mirrors.
+#[wasm_bindgen]
+pub fn dataflow_function_defs() -> Result<JsValue, JsValue> {
+    let defs = module_traits::builtin_function_defs();
+    serde_wasm_bindgen::to_value(&defs).map_err(|e| JsValue::from_str(&e.to_string()))
+}
+
+// ── MCU Pin Schema API ──────────────────────────────────────────────
+
+/// List all supported MCU target families.
+#[wasm_bindgen]
+pub fn mcu_families() -> JsValue {
+    let families = module_traits::inventory::supported_families();
+    serde_wasm_bindgen::to_value(&families).unwrap_or(JsValue::NULL)
+}
+
+/// Return the full MCU definition for a target family as JSON.
+///
+/// Includes all pins, peripherals, alternate functions, and clock config.
+/// The frontend uses this to build BSP configuration panels.
+#[wasm_bindgen]
+pub fn mcu_definition(family: &str) -> Result<JsValue, JsValue> {
+    let mcu = module_traits::inventory::mcu_for(family)
+        .ok_or_else(|| JsValue::from_str(&format!("unknown MCU family: {family}")))?;
+    serde_wasm_bindgen::to_value(&mcu).map_err(|e| JsValue::from_str(&e.to_string()))
+}
+
+/// Return just the pin definitions for a target family.
+///
+/// Each pin includes its name, port, alternate functions, and ADC channel.
+/// The frontend uses this to populate channel binding dropdowns.
+#[wasm_bindgen]
+pub fn mcu_pins(family: &str) -> Result<JsValue, JsValue> {
+    let mcu = module_traits::inventory::mcu_for(family)
+        .ok_or_else(|| JsValue::from_str(&format!("unknown MCU family: {family}")))?;
+    serde_wasm_bindgen::to_value(&mcu.pins).map_err(|e| JsValue::from_str(&e.to_string()))
+}
+
+/// Return peripheral instances for a target family.
+///
+/// Each peripheral includes its signals and available pin mappings.
+#[wasm_bindgen]
+pub fn mcu_peripherals(family: &str) -> Result<JsValue, JsValue> {
+    let mcu = module_traits::inventory::mcu_for(family)
+        .ok_or_else(|| JsValue::from_str(&format!("unknown MCU family: {family}")))?;
+    serde_wasm_bindgen::to_value(&mcu.peripherals)
+        .map_err(|e| JsValue::from_str(&e.to_string()))
+}
+
 /// Generate a standalone Rust crate from a dataflow graph.
 /// Returns JSON: `{ "files": [["path", "content"], ...] }` or error.
 #[wasm_bindgen]

--- a/mlir-codegen/src/dialect.rs
+++ b/mlir-codegen/src/dialect.rs
@@ -1,31 +1,59 @@
-//! Dataflow MLIR dialect: op names, type strings, and attribute formatting.
+//! MLIR dialect ops, type strings, and attribute formatting.
+//!
+//! Math operations use the standard MLIR `arith` dialect.
+//! I/O operations use `func.call` to named channel functions.
+//! Only truly hardware-specific ops remain in a minimal `builtin` namespace.
 
-/// MLIR dialect namespace prefix.
-pub const DIALECT: &str = "dataflow";
+/// MLIR namespace for hardware-specific ops not covered by standard dialects.
+pub const DIALECT: &str = "builtin";
 
-// -- Op names ---------------------------------------------------------------
+// -- Standard MLIR dialect ops (arith, func) --------------------------------
 
-pub const OP_CONSTANT: &str = "dataflow.constant";
-pub const OP_GAIN: &str = "dataflow.gain";
-pub const OP_ADD: &str = "dataflow.add";
-pub const OP_MUL: &str = "dataflow.mul";
-pub const OP_SUB: &str = "dataflow.subtract";
-pub const OP_CLAMP: &str = "dataflow.clamp";
-pub const OP_ADC_READ: &str = "dataflow.adc_read";
-pub const OP_PWM_WRITE: &str = "dataflow.pwm_write";
-pub const OP_GPIO_READ: &str = "dataflow.gpio_read";
-pub const OP_GPIO_WRITE: &str = "dataflow.gpio_write";
-pub const OP_UART_TX: &str = "dataflow.uart_tx";
-pub const OP_UART_RX: &str = "dataflow.uart_rx";
-pub const OP_ENCODER_READ: &str = "dataflow.encoder_read";
-pub const OP_DISPLAY_WRITE: &str = "dataflow.display_write";
-pub const OP_STEPPER_MOVE: &str = "dataflow.stepper_move";
-pub const OP_STEPPER_ENABLE: &str = "dataflow.stepper_enable";
-pub const OP_STEPPER_POSITION: &str = "dataflow.stepper_position";
-pub const OP_STALLGUARD_READ: &str = "dataflow.stallguard_read";
-pub const OP_SUBSCRIBE: &str = "dataflow.subscribe";
-pub const OP_PUBLISH: &str = "dataflow.publish";
-pub const OP_STATE_MACHINE: &str = "dataflow.state_machine";
+/// `arith.constant` — replaces the old `dataflow.constant`.
+pub const OP_CONSTANT: &str = "arith.constant";
+/// `arith.mulf` — gain is mul by a constant factor.
+pub const OP_GAIN: &str = "arith.mulf";
+/// `arith.addf`
+pub const OP_ADD: &str = "arith.addf";
+/// `arith.mulf` (two-input multiply)
+pub const OP_MUL: &str = "arith.mulf";
+/// `arith.subf`
+pub const OP_SUB: &str = "arith.subf";
+/// Clamp is compound: `arith.maximumf(min, arith.minimumf(max, x))`
+pub const OP_CLAMP: &str = "arith.maximumf";
+
+// -- I/O: modeled as func.call to named channel functions -------------------
+
+/// `func.call @adc_read_{ch}` — read from a typed ADC channel.
+pub const OP_ADC_READ: &str = "func.call";
+/// `func.call @pwm_write_{ch}` — write to a typed PWM channel.
+pub const OP_PWM_WRITE: &str = "func.call";
+/// `func.call @gpio_read_{pin}` — read GPIO pin.
+pub const OP_GPIO_READ: &str = "func.call";
+/// `func.call @gpio_write_{pin}` — write GPIO pin.
+pub const OP_GPIO_WRITE: &str = "func.call";
+/// `func.call @uart_tx_{port}` — transmit on UART.
+pub const OP_UART_TX: &str = "func.call";
+/// `func.call @uart_rx_{port}` — receive from UART.
+pub const OP_UART_RX: &str = "func.call";
+/// `func.call @encoder_read_{ch}` — read encoder position.
+pub const OP_ENCODER_READ: &str = "func.call";
+/// `func.call @display_write_{bus}_{addr}` — write to display.
+pub const OP_DISPLAY_WRITE: &str = "func.call";
+/// `func.call @stepper_move_{port}` — move stepper motor.
+pub const OP_STEPPER_MOVE: &str = "func.call";
+/// `func.call @stepper_enable_{port}` — enable stepper.
+pub const OP_STEPPER_ENABLE: &str = "func.call";
+/// `func.call @stepper_position_{port}` — read stepper position.
+pub const OP_STEPPER_POSITION: &str = "func.call";
+/// `func.call @stallguard_read_{port}` — read stallguard value.
+pub const OP_STALLGUARD_READ: &str = "func.call";
+/// `func.call @subscribe_{topic}` — subscribe to pub/sub topic.
+pub const OP_SUBSCRIBE: &str = "func.call";
+/// `func.call @publish_{topic}` — publish to pub/sub topic.
+pub const OP_PUBLISH: &str = "func.call";
+/// `scf.execute_region` — state machine uses structured control flow.
+pub const OP_STATE_MACHINE: &str = "scf.execute_region";
 
 // -- MLIR type strings ------------------------------------------------------
 

--- a/mlir-codegen/src/ir.rs
+++ b/mlir-codegen/src/ir.rs
@@ -322,6 +322,16 @@ impl IrBuilder {
         )[0]
     }
 
+    /// Emit select: result = cond > 0 ? a : b.
+    pub fn select(&mut self, cond: ValueId, a: ValueId, b: ValueId) -> ValueId {
+        self.typed_op(
+            IrOpKind::Arith(ArithOp::Select),
+            &[cond, a, b],
+            &[],
+            1,
+        )[0]
+    }
+
     // ── Hardware I/O ops ───────────────────────────────────────────
 
     /// ADC read: result = hw.adc_read(channel).

--- a/mlir-codegen/src/lib.rs
+++ b/mlir-codegen/src/lib.rs
@@ -138,7 +138,7 @@ mod tests {
             "time": 0.0
         }"#;
         let mlir = graph_json_to_mlir(json).unwrap();
-        assert!(mlir.contains("dataflow.constant"));
+        assert!(mlir.contains("arith.constant"));
         assert!(mlir.contains("99"));
         assert!(mlir.contains("func.func @tick"));
     }
@@ -171,7 +171,7 @@ mod tests {
             time: 0.0,
         };
         let output = compile_to_c(&snap).unwrap();
-        assert!(output.mlir_text.contains("dataflow.constant"));
+        assert!(output.mlir_text.contains("arith.constant"));
     }
 
     #[test]
@@ -365,11 +365,11 @@ mod tests {
         };
         let output = compile_to_c(&snap).unwrap();
         assert!(
-            output.mlir_text.contains("dataflow.constant"),
+            output.mlir_text.contains("arith.constant"),
             "MLIR should contain constant op"
         );
         assert!(
-            output.mlir_text.contains("dataflow.gain"),
+            output.mlir_text.contains("arith.mulf"),
             "MLIR should contain gain op"
         );
         assert!(

--- a/mlir-codegen/src/lower.rs
+++ b/mlir-codegen/src/lower.rs
@@ -1,17 +1,26 @@
-//! Lower a `GraphSnapshot` to textual MLIR in the `dataflow` dialect.
+//! Lower a `GraphSnapshot` to MLIR using standard arith/func dialects.
 //!
-//! This module replaces the string-interpolation Rust codegen in `emit.rs`
-//! with structured MLIR output. The generated `.mlir` is fed to `mlir-opt`
-//! and `mlir-translate` by the pipeline module.
+//! Math operations emit standard `arith.*` ops. I/O operations emit
+//! `func.call @channel_name(...)`. The [`FunctionDef`] registry provides
+//! `mlir_op` mappings so the lowerer can resolve block types to MLIR ops
+//! from the schema rather than hardcoding them.
 
 use std::collections::HashMap;
 use std::fmt::Write;
 
+use module_traits::function_def::{builtin_function_defs, FunctionDef};
 use module_traits::value::PortKind;
 use serde_json::Value as JsonValue;
 
 use crate::dialect;
 use crate::state_machine;
+
+/// Look up a [`FunctionDef`] by block type id.
+fn lookup_function_def(block_type: &str) -> Option<FunctionDef> {
+    builtin_function_defs()
+        .into_iter()
+        .find(|d| d.id == block_type)
+}
 
 // ---------------------------------------------------------------------------
 // Public types mirroring the main crate's graph types.
@@ -287,7 +296,37 @@ pub fn lower_graph(snap: &GraphSnapshot) -> Result<String, String> {
             "udp_source" => emit_udp_source(&mut out, id)?,
             "udp_sink" => emit_udp_sink(&mut out, id, &inputs)?,
             other => {
-                return Err(format!("unsupported block type for MLIR codegen: {other}"));
+                // Try schema-driven fallback: if the FunctionDef has a standard
+                // arith mlir_op and matching arity, emit it generically.
+                if let Some(def) = lookup_function_def(other) {
+                    if let Some(ref mlir_op) = def.mlir_op {
+                        let ssa = dialect::ssa_name(id, 0);
+                        match (mlir_op.as_str(), inputs.len()) {
+                            ("arith.addf" | "arith.subf" | "arith.mulf", _) if inputs.len() >= 2 => {
+                                let a = inputs.first().map(|s| s.as_str()).unwrap_or("%zero");
+                                let b = inputs.get(1).map(|s| s.as_str()).unwrap_or("%zero");
+                                writeln!(out, "    {ssa} = {mlir_op} {a}, {b} : f64").unwrap();
+                            }
+                            ("func.call", _) => {
+                                // Channel-binding function call
+                                if def.outputs.is_empty() {
+                                    let val = inputs.first().map(|s| s.as_str()).unwrap_or("%zero");
+                                    writeln!(out, "    func.call @{other}({val}) : (f64) -> ()").unwrap();
+                                } else {
+                                    writeln!(out, "    {ssa} = func.call @{other}() : () -> f64").unwrap();
+                                }
+                            }
+                            _ => {
+                                return Err(format!("unsupported block type for MLIR codegen: {other}"));
+                            }
+                        }
+                    } else {
+                        // No mlir_op → skip (UI-only block like plot)
+                        writeln!(out, "    // skipped: {other} (no MLIR mapping)").unwrap();
+                    }
+                } else {
+                    return Err(format!("unsupported block type for MLIR codegen: {other}"));
+                }
             }
         }
         writeln!(out).unwrap();
@@ -324,8 +363,12 @@ fn emit_gain(
     inputs: &[String],
 ) -> Result<(), String> {
     // Gain maps to: factor_const = arith.constant; out = arith.mulf(in, factor_const)
-    let factor = config_float(block, "param1")
-        .max(config_float(block, "gain")); // support both legacy and new param names
+    // Prefer "gain" (new schema), fall back to "param1" (legacy)
+    let factor = if block.config.get("gain").and_then(|v| v.as_f64()).is_some() {
+        config_float(block, "gain")
+    } else {
+        config_float(block, "param1")
+    };
     let input = inputs.first().map(|s| s.as_str()).unwrap_or("%zero");
     let factor_ssa = format!("%gain_factor_{id}");
     let ssa = dialect::ssa_name(id, 0);
@@ -370,8 +413,17 @@ fn emit_clamp(
     inputs: &[String],
 ) -> Result<(), String> {
     // clamp(x, lo, hi) = arith.maximumf(lo, arith.minimumf(hi, x))
-    let lo = config_float(block, "param1").max(config_float(block, "min"));
-    let hi = config_float(block, "param2").max(config_float(block, "max"));
+    // Prefer "min"/"max" (new schema), fall back to "param1"/"param2" (legacy)
+    let lo = if block.config.get("min").and_then(|v| v.as_f64()).is_some() {
+        config_float(block, "min")
+    } else {
+        config_float(block, "param1")
+    };
+    let hi = if block.config.get("max").and_then(|v| v.as_f64()).is_some() {
+        config_float(block, "max")
+    } else {
+        config_float(block, "param2")
+    };
     let input = inputs.first().map(|s| s.as_str()).unwrap_or("%zero");
     let lo_ssa = format!("%clamp_lo_{id}");
     let hi_ssa = format!("%clamp_hi_{id}");
@@ -634,13 +686,13 @@ fn emit_channel_read(out: &mut String, id: u32, block: &BlockSnapshot) -> Result
 
 fn emit_channel_write(
     out: &mut String,
-    _id: u32,
+    id: u32,
     block: &BlockSnapshot,
     inputs: &[String],
 ) -> Result<(), String> {
     let channel = config_str(block, "channel");
     let ch_name = if channel.is_empty() {
-        format!("ch_{_id}")
+        format!("ch_{id}")
     } else {
         channel.to_string()
     };
@@ -734,7 +786,12 @@ pub fn lower_graph_ir(snap: &GraphSnapshot) -> Result<IrModule, String> {
             }
             "gain" => {
                 let input = inputs.first().copied().unwrap_or(zero);
-                let factor = builder.constant_f64(config_float(block, "param1"));
+                let gain_val = if block.config.get("gain").and_then(|v| v.as_f64()).is_some() {
+                    config_float(block, "gain")
+                } else {
+                    config_float(block, "param1")
+                };
+                let factor = builder.constant_f64(gain_val);
                 let v = builder.mulf(input, factor);
                 output_map.insert((id, 0), v);
             }
@@ -758,8 +815,16 @@ pub fn lower_graph_ir(snap: &GraphSnapshot) -> Result<IrModule, String> {
             }
             "clamp" => {
                 let input = inputs.first().copied().unwrap_or(zero);
-                let lo = config_float(block, "param1").max(config_float(block, "min"));
-                let hi = config_float(block, "param2").max(config_float(block, "max"));
+                let lo = if block.config.get("min").and_then(|v| v.as_f64()).is_some() {
+                    config_float(block, "min")
+                } else {
+                    config_float(block, "param1")
+                };
+                let hi = if block.config.get("max").and_then(|v| v.as_f64()).is_some() {
+                    config_float(block, "max")
+                } else {
+                    config_float(block, "param2")
+                };
                 let v = builder.clamp(input, lo, hi);
                 output_map.insert((id, 0), v);
             }
@@ -1731,5 +1796,148 @@ mod tests {
         let result = lower_graph_ir(&snap);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("cycle"));
+    }
+
+    // ── New block type lowering tests ─────────────────────────────
+
+    #[test]
+    fn lower_select_block() {
+        let blocks = vec![
+            make_block(1, "constant", serde_json::json!({"value": 1.0})),
+            make_block(2, "constant", serde_json::json!({"value": 10.0})),
+            make_block(3, "constant", serde_json::json!({"value": 20.0})),
+            {
+                let mut b = make_block(4, "select", serde_json::json!({}));
+                b.inputs = vec![
+                    PortDef { name: "cond".to_string(), kind: PortKind::Float },
+                    PortDef { name: "a".to_string(), kind: PortKind::Float },
+                    PortDef { name: "b".to_string(), kind: PortKind::Float },
+                ];
+                b
+            },
+        ];
+        let channels = vec![
+            make_channel(1, 1, 0, 4, 0),
+            make_channel(2, 2, 0, 4, 1),
+            make_channel(3, 3, 0, 4, 2),
+        ];
+        let snap = GraphSnapshot { blocks, channels, tick_count: 0, time: 0.0 };
+        let mlir = lower_graph(&snap).unwrap();
+        assert!(mlir.contains("arith.cmpf"), "expected cmpf for select guard, got:\n{mlir}");
+        assert!(mlir.contains("arith.select"), "expected arith.select, got:\n{mlir}");
+    }
+
+    #[test]
+    fn lower_channel_read_write() {
+        let blocks = vec![
+            {
+                let mut b = make_block(1, "channel_read", serde_json::json!({"channel": "adc0"}));
+                b.inputs = vec![];
+                b
+            },
+            {
+                let mut b = make_block(2, "channel_write", serde_json::json!({"channel": "pwm0"}));
+                b.inputs = vec![PortDef { name: "value".to_string(), kind: PortKind::Float }];
+                b.outputs = vec![];
+                b
+            },
+        ];
+        let channels = vec![make_channel(1, 1, 0, 2, 0)];
+        let snap = GraphSnapshot { blocks, channels, tick_count: 0, time: 0.0 };
+        let mlir = lower_graph(&snap).unwrap();
+        assert!(
+            mlir.contains("func.call @channel_read_adc0"),
+            "expected channel_read call, got:\n{mlir}"
+        );
+        assert!(
+            mlir.contains("func.call @channel_write_pwm0"),
+            "expected channel_write call, got:\n{mlir}"
+        );
+    }
+
+    #[test]
+    fn lower_gain_new_schema() {
+        // Test gain block with new "gain" param key (not legacy "param1")
+        let blocks = vec![
+            make_block(1, "constant", serde_json::json!({"value": 5.0})),
+            {
+                let mut b = make_block(2, "gain", serde_json::json!({"gain": 4.0}));
+                b.inputs = vec![PortDef { name: "in".to_string(), kind: PortKind::Float }];
+                b
+            },
+        ];
+        let channels = vec![make_channel(1, 1, 0, 2, 0)];
+        let snap = GraphSnapshot { blocks, channels, tick_count: 0, time: 0.0 };
+        let mlir = lower_graph(&snap).unwrap();
+        assert!(mlir.contains("arith.constant 4"), "expected gain factor 4, got:\n{mlir}");
+        assert!(mlir.contains("arith.mulf %v1_p0"), "expected mulf using constant output, got:\n{mlir}");
+    }
+
+    #[test]
+    fn lower_clamp_new_schema() {
+        // Test clamp block with new "min"/"max" param keys
+        let blocks = vec![
+            make_block(1, "constant", serde_json::json!({"value": 50.0})),
+            {
+                let mut b = make_block(2, "clamp", serde_json::json!({"min": -10.0, "max": 10.0}));
+                b.inputs = vec![PortDef { name: "in".to_string(), kind: PortKind::Float }];
+                b
+            },
+        ];
+        let channels = vec![make_channel(1, 1, 0, 2, 0)];
+        let snap = GraphSnapshot { blocks, channels, tick_count: 0, time: 0.0 };
+        let mlir = lower_graph(&snap).unwrap();
+        assert!(mlir.contains("-10"), "expected min bound -10, got:\n{mlir}");
+        assert!(mlir.contains("arith.minimumf"), "expected minimumf for clamp, got:\n{mlir}");
+        assert!(mlir.contains("arith.maximumf"), "expected maximumf for clamp, got:\n{mlir}");
+    }
+
+    #[test]
+    fn lower_ir_select_block() {
+        let blocks = vec![
+            make_block(1, "constant", serde_json::json!({"value": 1.0})),
+            make_block(2, "constant", serde_json::json!({"value": 5.0})),
+            make_block(3, "constant", serde_json::json!({"value": 9.0})),
+            {
+                let mut b = make_block(4, "select", serde_json::json!({}));
+                b.inputs = vec![
+                    PortDef { name: "cond".to_string(), kind: PortKind::Float },
+                    PortDef { name: "a".to_string(), kind: PortKind::Float },
+                    PortDef { name: "b".to_string(), kind: PortKind::Float },
+                ];
+                b
+            },
+        ];
+        let channels = vec![
+            make_channel(1, 1, 0, 4, 0),
+            make_channel(2, 2, 0, 4, 1),
+            make_channel(3, 3, 0, 4, 2),
+        ];
+        let snap = GraphSnapshot { blocks, channels, tick_count: 0, time: 0.0 };
+        let module = lower_graph_ir(&snap).unwrap();
+        // 4 constants (zero + 3 block constants) + 1 select = at least 5 ops
+        assert!(module.funcs[0].ops.len() >= 5, "expected at least 5 ops");
+    }
+
+    #[test]
+    fn lower_ir_channel_read_write() {
+        let blocks = vec![
+            {
+                let mut b = make_block(1, "channel_read", serde_json::json!({"channel": "sensor"}));
+                b.inputs = vec![];
+                b
+            },
+            {
+                let mut b = make_block(2, "channel_write", serde_json::json!({"channel": "actuator"}));
+                b.inputs = vec![PortDef { name: "value".to_string(), kind: PortKind::Float }];
+                b.outputs = vec![];
+                b
+            },
+        ];
+        let channels = vec![make_channel(1, 1, 0, 2, 0)];
+        let snap = GraphSnapshot { blocks, channels, tick_count: 0, time: 0.0 };
+        let module = lower_graph_ir(&snap).unwrap();
+        // zero const + subscribe(channel_read) + publish(channel_write) = 3 ops
+        assert!(module.funcs[0].ops.len() >= 3);
     }
 }

--- a/mlir-codegen/src/lower.rs
+++ b/mlir-codegen/src/lower.rs
@@ -266,6 +266,9 @@ pub fn lower_graph(snap: &GraphSnapshot) -> Result<String, String> {
             "subtract" => emit_subtract(&mut out, id, &inputs)?,
             "multiply" => emit_multiply(&mut out, id, &inputs)?,
             "clamp" => emit_clamp(&mut out, id, block, &inputs)?,
+            "select" => emit_select(&mut out, id, &inputs)?,
+            "channel_read" => emit_channel_read(&mut out, id, block)?,
+            "channel_write" => emit_channel_write(&mut out, id, block, &inputs)?,
             "adc_source" => emit_adc_read(&mut out, id, block)?,
             "pwm_sink" => emit_pwm_write(&mut out, id, block, &inputs)?,
             "gpio_out" => emit_gpio_write(&mut out, id, block, &inputs)?,
@@ -307,8 +310,7 @@ fn emit_constant(out: &mut String, id: u32, block: &BlockSnapshot) -> Result<(),
     let ssa = dialect::ssa_name(id, 0);
     writeln!(
         out,
-        "    {ssa} = {op} {attr}",
-        op = dialect::OP_CONSTANT,
+        "    {ssa} = arith.constant {attr}",
         attr = dialect::float_attr(value),
     )
     .unwrap();
@@ -321,16 +323,19 @@ fn emit_gain(
     block: &BlockSnapshot,
     inputs: &[String],
 ) -> Result<(), String> {
-    let factor = config_float(block, "param1");
+    // Gain maps to: factor_const = arith.constant; out = arith.mulf(in, factor_const)
+    let factor = config_float(block, "param1")
+        .max(config_float(block, "gain")); // support both legacy and new param names
     let input = inputs.first().map(|s| s.as_str()).unwrap_or("%zero");
+    let factor_ssa = format!("%gain_factor_{id}");
     let ssa = dialect::ssa_name(id, 0);
     writeln!(
         out,
-        "    {ssa} = {op}({input}) {{ factor = {attr} }} : f64",
-        op = dialect::OP_GAIN,
+        "    {factor_ssa} = arith.constant {attr}",
         attr = dialect::float_attr(factor),
     )
     .unwrap();
+    writeln!(out, "    {ssa} = arith.mulf {input}, {factor_ssa} : f64").unwrap();
     Ok(())
 }
 
@@ -338,12 +343,7 @@ fn emit_add(out: &mut String, id: u32, inputs: &[String]) -> Result<(), String> 
     let a = inputs.first().map(|s| s.as_str()).unwrap_or("%zero");
     let b = inputs.get(1).map(|s| s.as_str()).unwrap_or("%zero");
     let ssa = dialect::ssa_name(id, 0);
-    writeln!(
-        out,
-        "    {ssa} = {op}({a}, {b}) : f64",
-        op = dialect::OP_ADD,
-    )
-    .unwrap();
+    writeln!(out, "    {ssa} = arith.addf {a}, {b} : f64").unwrap();
     Ok(())
 }
 
@@ -351,12 +351,7 @@ fn emit_multiply(out: &mut String, id: u32, inputs: &[String]) -> Result<(), Str
     let a = inputs.first().map(|s| s.as_str()).unwrap_or("%zero");
     let b = inputs.get(1).map(|s| s.as_str()).unwrap_or("%zero");
     let ssa = dialect::ssa_name(id, 0);
-    writeln!(
-        out,
-        "    {ssa} = {op}({a}, {b}) : f64",
-        op = dialect::OP_MUL,
-    )
-    .unwrap();
+    writeln!(out, "    {ssa} = arith.mulf {a}, {b} : f64").unwrap();
     Ok(())
 }
 
@@ -364,12 +359,7 @@ fn emit_subtract(out: &mut String, id: u32, inputs: &[String]) -> Result<(), Str
     let a = inputs.first().map(|s| s.as_str()).unwrap_or("%zero");
     let b = inputs.get(1).map(|s| s.as_str()).unwrap_or("%zero");
     let ssa = dialect::ssa_name(id, 0);
-    writeln!(
-        out,
-        "    {ssa} = {op}({a}, {b}) : f64",
-        op = dialect::OP_SUB,
-    )
-    .unwrap();
+    writeln!(out, "    {ssa} = arith.subf {a}, {b} : f64").unwrap();
     Ok(())
 }
 
@@ -379,18 +369,18 @@ fn emit_clamp(
     block: &BlockSnapshot,
     inputs: &[String],
 ) -> Result<(), String> {
-    let min = config_float(block, "param1");
-    let max = config_float(block, "param2");
+    // clamp(x, lo, hi) = arith.maximumf(lo, arith.minimumf(hi, x))
+    let lo = config_float(block, "param1").max(config_float(block, "min"));
+    let hi = config_float(block, "param2").max(config_float(block, "max"));
     let input = inputs.first().map(|s| s.as_str()).unwrap_or("%zero");
+    let lo_ssa = format!("%clamp_lo_{id}");
+    let hi_ssa = format!("%clamp_hi_{id}");
+    let min_ssa = format!("%clamp_min_{id}");
     let ssa = dialect::ssa_name(id, 0);
-    writeln!(
-        out,
-        "    {ssa} = {op}({input}) {{ min = {min_attr}, max = {max_attr} }} : f64",
-        op = dialect::OP_CLAMP,
-        min_attr = dialect::float_attr(min),
-        max_attr = dialect::float_attr(max),
-    )
-    .unwrap();
+    writeln!(out, "    {lo_ssa} = arith.constant {}", dialect::float_attr(lo)).unwrap();
+    writeln!(out, "    {hi_ssa} = arith.constant {}", dialect::float_attr(hi)).unwrap();
+    writeln!(out, "    {min_ssa} = arith.minimumf {input}, {hi_ssa} : f64").unwrap();
+    writeln!(out, "    {ssa} = arith.maximumf {min_ssa}, {lo_ssa} : f64").unwrap();
     Ok(())
 }
 
@@ -399,9 +389,7 @@ fn emit_adc_read(out: &mut String, id: u32, block: &BlockSnapshot) -> Result<(),
     let ssa = dialect::ssa_name(id, 0);
     writeln!(
         out,
-        "    {ssa} = {op} {{ channel = {attr} }} : f64",
-        op = dialect::OP_ADC_READ,
-        attr = dialect::i32_attr(channel as i32),
+        "    {ssa} = func.call @adc_read_{channel}() : () -> f64",
     )
     .unwrap();
     Ok(())
@@ -417,9 +405,7 @@ fn emit_pwm_write(
     let duty = inputs.first().map(|s| s.as_str()).unwrap_or("%zero");
     writeln!(
         out,
-        "    {op}({duty}) {{ channel = {attr} }}",
-        op = dialect::OP_PWM_WRITE,
-        attr = dialect::i32_attr(channel as i32),
+        "    func.call @pwm_write_{channel}({duty}) : (f64) -> ()",
     )
     .unwrap();
     Ok(())
@@ -435,9 +421,7 @@ fn emit_gpio_write(
     let val = inputs.first().map(|s| s.as_str()).unwrap_or("%zero");
     writeln!(
         out,
-        "    {op}({val}) {{ pin = {attr} }}",
-        op = dialect::OP_GPIO_WRITE,
-        attr = dialect::i32_attr(pin as i32),
+        "    func.call @gpio_write_{pin}({val}) : (f64) -> ()",
     )
     .unwrap();
     Ok(())
@@ -448,9 +432,7 @@ fn emit_gpio_read(out: &mut String, id: u32, block: &BlockSnapshot) -> Result<()
     let ssa = dialect::ssa_name(id, 0);
     writeln!(
         out,
-        "    {ssa} = {op} {{ pin = {attr} }} : f64",
-        op = dialect::OP_GPIO_READ,
-        attr = dialect::i32_attr(pin as i32),
+        "    {ssa} = func.call @gpio_read_{pin}() : () -> f64",
     )
     .unwrap();
     Ok(())
@@ -466,9 +448,7 @@ fn emit_uart_tx(
     let data = inputs.first().map(|s| s.as_str()).unwrap_or("%zero");
     writeln!(
         out,
-        "    {op}({data}) {{ port = {attr} }}",
-        op = dialect::OP_UART_TX,
-        attr = dialect::i32_attr(port as i32),
+        "    func.call @uart_tx_{port}({data}) : (f64) -> ()",
     )
     .unwrap();
     Ok(())
@@ -479,9 +459,7 @@ fn emit_uart_rx(out: &mut String, id: u32, block: &BlockSnapshot) -> Result<(), 
     let ssa = dialect::ssa_name(id, 0);
     writeln!(
         out,
-        "    {ssa} = {op} {{ port = {attr} }} : f64",
-        op = dialect::OP_UART_RX,
-        attr = dialect::i32_attr(port as i32),
+        "    {ssa} = func.call @uart_rx_{port}() : () -> f64",
     )
     .unwrap();
     Ok(())
@@ -493,9 +471,7 @@ fn emit_encoder_read(out: &mut String, id: u32, block: &BlockSnapshot) -> Result
     let ssa_vel = dialect::ssa_name(id, 1);
     writeln!(
         out,
-        "    {ssa_pos} = {op} {{ channel = {attr} }} : f64",
-        op = dialect::OP_ENCODER_READ,
-        attr = dialect::i32_attr(channel as i32),
+        "    {ssa_pos} = func.call @encoder_read_{channel}() : () -> f64",
     )
     .unwrap();
     // Velocity is a derived value — emit zero placeholder
@@ -519,10 +495,7 @@ fn emit_display_write(
     let line2 = inputs.get(1).map(|s| s.as_str()).unwrap_or("%zero");
     writeln!(
         out,
-        "    {op}({line1}, {line2}) {{ bus = {bus_attr}, addr = {addr_attr} }}",
-        op = dialect::OP_DISPLAY_WRITE,
-        bus_attr = dialect::i32_attr(bus as i32),
-        addr_attr = dialect::i32_attr(addr as i32),
+        "    func.call @display_write_{bus}_{addr}({line1}, {line2}) : (f64, f64) -> ()",
     )
     .unwrap();
     Ok(())
@@ -537,25 +510,21 @@ fn emit_stepper(
     let port = config_u64(block, "uart_port");
     let target = inputs.first().map(|s| s.as_str()).unwrap_or("%zero");
     let enable = inputs.get(1).map(|s| s.as_str()).unwrap_or("%zero");
-    let port_attr = dialect::i32_attr(port as i32);
 
     writeln!(
         out,
-        "    {op}({enable}) {{ port = {port_attr} }}",
-        op = dialect::OP_STEPPER_ENABLE,
+        "    func.call @stepper_enable_{port}({enable}) : (f64) -> ()",
     )
     .unwrap();
     writeln!(
         out,
-        "    {op}({target}) {{ port = {port_attr} }}",
-        op = dialect::OP_STEPPER_MOVE,
+        "    func.call @stepper_move_{port}({target}) : (f64) -> ()",
     )
     .unwrap();
     let ssa = dialect::ssa_name(id, 0);
     writeln!(
         out,
-        "    {ssa} = {op} {{ port = {port_attr} }} : f64",
-        op = dialect::OP_STEPPER_POSITION,
+        "    {ssa} = func.call @stepper_position_{port}() : () -> f64",
     )
     .unwrap();
     Ok(())
@@ -570,13 +539,10 @@ fn emit_stallguard(out: &mut String, id: u32, block: &BlockSnapshot) -> Result<(
 
     writeln!(
         out,
-        "    {ssa_val} = {op} {{ port = {port_attr}, addr = {addr_attr} }} : f64",
-        op = dialect::OP_STALLGUARD_READ,
-        port_attr = dialect::i32_attr(port as i32),
-        addr_attr = dialect::i32_attr(addr as i32),
+        "    {ssa_val} = func.call @stallguard_read_{port}_{addr}() : () -> f64",
     )
     .unwrap();
-    // Stall detection: value < threshold → 1.0
+    // Stall detection: value < threshold → 1.0 (arith dialect)
     writeln!(out, "    // stall detection: threshold = {threshold}").unwrap();
     let threshold_ssa = format!("%sg_thresh_{id}");
     writeln!(
@@ -608,12 +574,11 @@ fn emit_pubsub_sink(
     inputs: &[String],
 ) -> Result<(), String> {
     let topic = config_str(block, "topic");
+    let t = if topic.is_empty() { "unknown" } else { topic };
     let val = inputs.first().map(|s| s.as_str()).unwrap_or("%zero");
     writeln!(
         out,
-        "    {op}({val}) {{ topic = {attr} }}",
-        op = dialect::OP_PUBLISH,
-        attr = dialect::string_attr(if topic.is_empty() { "unknown" } else { topic }),
+        "    func.call @publish_{t}({val}) : (f64) -> ()",
     )
     .unwrap();
     Ok(())
@@ -621,12 +586,68 @@ fn emit_pubsub_sink(
 
 fn emit_pubsub_source(out: &mut String, id: u32, block: &BlockSnapshot) -> Result<(), String> {
     let topic = config_str(block, "topic");
+    let t = if topic.is_empty() { "unknown" } else { topic };
     let ssa = dialect::ssa_name(id, 0);
     writeln!(
         out,
-        "    {ssa} = {op} {{ topic = {attr} }} : f64",
-        op = dialect::OP_SUBSCRIBE,
-        attr = dialect::string_attr(if topic.is_empty() { "unknown" } else { topic }),
+        "    {ssa} = func.call @subscribe_{t}() : () -> f64",
+    )
+    .unwrap();
+    Ok(())
+}
+
+fn emit_select(out: &mut String, id: u32, inputs: &[String]) -> Result<(), String> {
+    let cond = inputs.first().map(|s| s.as_str()).unwrap_or("%zero");
+    let a = inputs.get(1).map(|s| s.as_str()).unwrap_or("%zero");
+    let b = inputs.get(2).map(|s| s.as_str()).unwrap_or("%zero");
+    let cmp_ssa = format!("%sel_cmp_{id}");
+    let ssa = dialect::ssa_name(id, 0);
+    // cond > 0 → i1
+    writeln!(
+        out,
+        "    {cmp_ssa} = arith.cmpf \"ogt\", {cond}, %zero : f64"
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "    {ssa} = arith.select {cmp_ssa}, {a}, {b} : f64"
+    )
+    .unwrap();
+    Ok(())
+}
+
+fn emit_channel_read(out: &mut String, id: u32, block: &BlockSnapshot) -> Result<(), String> {
+    let channel = config_str(block, "channel");
+    let ch_name = if channel.is_empty() {
+        format!("ch_{id}")
+    } else {
+        channel.to_string()
+    };
+    let ssa = dialect::ssa_name(id, 0);
+    writeln!(
+        out,
+        "    {ssa} = func.call @channel_read_{ch_name}() : () -> f64",
+    )
+    .unwrap();
+    Ok(())
+}
+
+fn emit_channel_write(
+    out: &mut String,
+    _id: u32,
+    block: &BlockSnapshot,
+    inputs: &[String],
+) -> Result<(), String> {
+    let channel = config_str(block, "channel");
+    let ch_name = if channel.is_empty() {
+        format!("ch_{_id}")
+    } else {
+        channel.to_string()
+    };
+    let val = inputs.first().map(|s| s.as_str()).unwrap_or("%zero");
+    writeln!(
+        out,
+        "    func.call @channel_write_{ch_name}({val}) : (f64) -> ()",
     )
     .unwrap();
     Ok(())
@@ -737,10 +758,37 @@ pub fn lower_graph_ir(snap: &GraphSnapshot) -> Result<IrModule, String> {
             }
             "clamp" => {
                 let input = inputs.first().copied().unwrap_or(zero);
-                let lo = config_float(block, "param1");
-                let hi = config_float(block, "param2");
+                let lo = config_float(block, "param1").max(config_float(block, "min"));
+                let hi = config_float(block, "param2").max(config_float(block, "max"));
                 let v = builder.clamp(input, lo, hi);
                 output_map.insert((id, 0), v);
+            }
+            "select" => {
+                let cond = inputs.first().copied().unwrap_or(zero);
+                let a = inputs.get(1).copied().unwrap_or(zero);
+                let b = inputs.get(2).copied().unwrap_or(zero);
+                let v = builder.select(cond, a, b);
+                output_map.insert((id, 0), v);
+            }
+            "channel_read" => {
+                let channel = config_str(block, "channel");
+                let ch_name = if channel.is_empty() {
+                    format!("ch_{id}")
+                } else {
+                    channel.to_string()
+                };
+                let v = builder.subscribe(&ch_name);
+                output_map.insert((id, 0), v);
+            }
+            "channel_write" => {
+                let channel = config_str(block, "channel");
+                let ch_name = if channel.is_empty() {
+                    format!("ch_{id}")
+                } else {
+                    channel.to_string()
+                };
+                let input = inputs.first().copied().unwrap_or(zero);
+                builder.publish(&ch_name, input);
             }
             "adc_source" => {
                 let channel = config_u64(block, "channel") as u8;
@@ -849,7 +897,7 @@ mod tests {
             time: 0.0,
         };
         let mlir = lower_graph(&snap).unwrap();
-        assert!(mlir.contains("dataflow.constant"));
+        assert!(mlir.contains("arith.constant"));
         assert!(mlir.contains("42"));
         assert!(mlir.contains("%v1_p0"));
     }
@@ -875,8 +923,8 @@ mod tests {
             time: 0.0,
         };
         let mlir = lower_graph(&snap).unwrap();
-        assert!(mlir.contains("dataflow.gain(%v1_p0)"));
-        assert!(mlir.contains("factor = 3"));
+        assert!(mlir.contains("arith.mulf %v1_p0"));
+        assert!(mlir.contains("3"), "expected gain factor 3 in output");
     }
 
     #[test]
@@ -907,7 +955,7 @@ mod tests {
             time: 0.0,
         };
         let mlir = lower_graph(&snap).unwrap();
-        assert!(mlir.contains("dataflow.add(%v1_p0, %v2_p0)"));
+        assert!(mlir.contains("arith.addf %v1_p0, %v2_p0"));
     }
 
     #[test]
@@ -936,8 +984,8 @@ mod tests {
             time: 0.0,
         };
         let mlir = lower_graph(&snap).unwrap();
-        assert!(mlir.contains("dataflow.adc_read"));
-        assert!(mlir.contains("dataflow.pwm_write(%v1_p0)"));
+        assert!(mlir.contains("func.call @adc_read"));
+        assert!(mlir.contains("func.call @pwm_write"));
     }
 
     #[test]
@@ -985,7 +1033,7 @@ mod tests {
             time: 0.0,
         };
         let mlir = lower_graph(&snap).unwrap();
-        assert!(mlir.contains("dataflow.constant"));
+        assert!(mlir.contains("arith.constant"));
         assert!(!mlir.contains("plot"));
     }
 
@@ -1020,8 +1068,8 @@ mod tests {
             time: 0.0,
         };
         let mlir = lower_graph(&snap).unwrap();
-        assert!(mlir.contains("dataflow.subscribe"));
-        assert!(mlir.contains("dataflow.publish"));
+        assert!(mlir.contains("func.call @subscribe"));
+        assert!(mlir.contains("func.call @publish"));
         assert!(mlir.contains("bridge_1_0"));
     }
 
@@ -1054,8 +1102,8 @@ mod tests {
         };
         let mlir = lower_graph(&snap).unwrap();
         assert!(
-            mlir.contains("dataflow.subtract(%v1_p0, %v2_p0)"),
-            "expected dataflow.subtract with wired inputs, got:\n{mlir}"
+            mlir.contains("arith.subf %v1_p0, %v2_p0"),
+            "expected arith.subf with wired inputs, got:\n{mlir}"
         );
     }
 
@@ -1085,16 +1133,12 @@ mod tests {
         };
         let mlir = lower_graph(&snap).unwrap();
         assert!(
-            mlir.contains("dataflow.clamp(%v1_p0)"),
-            "expected dataflow.clamp with wired input, got:\n{mlir}"
+            mlir.contains("arith.maximumf") && mlir.contains("arith.minimumf"),
+            "expected arith clamp ops, got:\n{mlir}"
         );
         assert!(
-            mlir.contains("min ="),
-            "expected min attribute in clamp, got:\n{mlir}"
-        );
-        assert!(
-            mlir.contains("max ="),
-            "expected max attribute in clamp, got:\n{mlir}"
+            mlir.contains("arith.constant"),
+            "expected arith.constant for clamp bounds, got:\n{mlir}"
         );
     }
 
@@ -1113,12 +1157,12 @@ mod tests {
         };
         let mlir = lower_graph(&snap).unwrap();
         assert!(
-            mlir.contains("dataflow.adc_read"),
-            "expected dataflow.adc_read op, got:\n{mlir}"
+            mlir.contains("func.call @adc_read"),
+            "expected func.call @adc_read op, got:\n{mlir}"
         );
         assert!(
-            mlir.contains("channel = 2 : i32"),
-            "expected channel attribute of 2, got:\n{mlir}"
+            mlir.contains("adc_read_2"),
+            "expected adc_read_2 channel call, got:\n{mlir}"
         );
     }
 
@@ -1145,12 +1189,12 @@ mod tests {
         };
         let mlir = lower_graph(&snap).unwrap();
         assert!(
-            mlir.contains("dataflow.pwm_write(%v1_p0)"),
-            "expected dataflow.pwm_write with wired input, got:\n{mlir}"
+            mlir.contains("func.call @pwm_write"),
+            "expected func.call @pwm_write with wired input, got:\n{mlir}"
         );
         assert!(
-            mlir.contains("channel = 3 : i32"),
-            "expected channel attribute of 3, got:\n{mlir}"
+            mlir.contains("pwm_write_3"),
+            "expected pwm_write_3 channel call, got:\n{mlir}"
         );
     }
 
@@ -1183,7 +1227,7 @@ mod tests {
         );
         // The gain block 2 must use %v1_p0 as its input operand
         assert!(
-            mlir.contains("dataflow.gain(%v1_p0)"),
+            mlir.contains("arith.mulf %v1_p0"),
             "expected gain to reference constant's SSA value, got:\n{mlir}"
         );
         // The gain block 2 produces %v2_p0
@@ -1219,8 +1263,8 @@ mod tests {
             time: 0.0,
         };
         let mlir = lower_graph(&snap).unwrap();
-        assert!(mlir.contains("dataflow.gpio_read"), "got:\n{mlir}");
-        assert!(mlir.contains("dataflow.gpio_write"), "got:\n{mlir}");
+        assert!(mlir.contains("func.call @gpio_read"), "got:\n{mlir}");
+        assert!(mlir.contains("func.call @gpio_write"), "got:\n{mlir}");
     }
 
     #[test]
@@ -1249,8 +1293,8 @@ mod tests {
             time: 0.0,
         };
         let mlir = lower_graph(&snap).unwrap();
-        assert!(mlir.contains("dataflow.uart_rx"), "got:\n{mlir}");
-        assert!(mlir.contains("dataflow.uart_tx"), "got:\n{mlir}");
+        assert!(mlir.contains("func.call @uart_rx"), "got:\n{mlir}");
+        assert!(mlir.contains("func.call @uart_tx"), "got:\n{mlir}");
     }
 
     #[test]
@@ -1277,7 +1321,7 @@ mod tests {
             time: 0.0,
         };
         let mlir = lower_graph(&snap).unwrap();
-        assert!(mlir.contains("dataflow.encoder_read"), "got:\n{mlir}");
+        assert!(mlir.contains("func.call @encoder_read"), "got:\n{mlir}");
     }
 
     #[test]
@@ -1313,7 +1357,7 @@ mod tests {
             time: 0.0,
         };
         let mlir = lower_graph(&snap).unwrap();
-        assert!(mlir.contains("dataflow.display_write"), "got:\n{mlir}");
+        assert!(mlir.contains("func.call @display_write"), "got:\n{mlir}");
     }
 
     #[test]
@@ -1344,9 +1388,9 @@ mod tests {
             time: 0.0,
         };
         let mlir = lower_graph(&snap).unwrap();
-        assert!(mlir.contains("dataflow.stepper_move"), "got:\n{mlir}");
-        assert!(mlir.contains("dataflow.stepper_enable"), "got:\n{mlir}");
-        assert!(mlir.contains("dataflow.stepper_position"), "got:\n{mlir}");
+        assert!(mlir.contains("func.call @stepper_move"), "got:\n{mlir}");
+        assert!(mlir.contains("func.call @stepper_enable"), "got:\n{mlir}");
+        assert!(mlir.contains("func.call @stepper_position"), "got:\n{mlir}");
     }
 
     #[test]
@@ -1377,7 +1421,7 @@ mod tests {
             time: 0.0,
         };
         let mlir = lower_graph(&snap).unwrap();
-        assert!(mlir.contains("dataflow.stallguard_read"), "got:\n{mlir}");
+        assert!(mlir.contains("func.call @stallguard_read"), "got:\n{mlir}");
     }
 
     #[test]
@@ -1461,12 +1505,12 @@ mod tests {
         let mlir = lower_graph(&snap).unwrap();
         // First gain uses the constant's output
         assert!(
-            mlir.contains("dataflow.gain(%v1_p0)"),
+            mlir.contains("arith.mulf %v1_p0"),
             "expected first gain to use %v1_p0, got:\n{mlir}"
         );
         // Second gain uses the first gain's output
         assert!(
-            mlir.contains("dataflow.gain(%v2_p0)"),
+            mlir.contains("arith.mulf %v2_p0"),
             "expected second gain to use %v2_p0, got:\n{mlir}"
         );
         // The final output SSA is %v3_p0

--- a/mlir-codegen/src/pipeline.rs
+++ b/mlir-codegen/src/pipeline.rs
@@ -351,7 +351,7 @@ mod tests {
     fn lower_only_produces_mlir() {
         let snap = simple_graph();
         let output = lower_only(&snap).unwrap();
-        assert!(output.mlir_text.contains("dataflow.constant"));
+        assert!(output.mlir_text.contains("arith.constant"));
         assert!(output.mlir_optimized.is_none());
         assert!(output.c_source.is_none());
     }

--- a/mlir-codegen/src/state_machine.rs
+++ b/mlir-codegen/src/state_machine.rs
@@ -137,7 +137,7 @@ pub fn emit_state_machine_tick(
                             .unwrap();
                             writeln!(
                                 out,
-                                "        {field_ssa} = dataflow.message_field {guard_ssa}, \"{field}\" : f64"
+                                "        {field_ssa} = builtin.extract_field {guard_ssa}, \"{field}\" : f64"
                             )
                             .unwrap();
                             writeln!(
@@ -345,7 +345,7 @@ mod tests {
         let inputs = vec!["%g0".to_string(), "%g1".to_string()];
         let mut out = String::new();
         emit_state_machine_tick(&mut out, 10, &block, &inputs).unwrap();
-        assert!(out.contains("dataflow.state_machine"));
+        assert!(out.contains("scf.execute_region"));
         assert!(out.contains("^idle"));
         assert!(out.contains("^running"));
         assert!(out.contains("cf.cond_br"));
@@ -389,10 +389,10 @@ mod tests {
         let inputs = vec!["%motor_cmd".to_string()];
         let mut out = String::new();
         emit_state_machine_tick(&mut out, 20, &block, &inputs).unwrap();
-        assert!(out.contains("dataflow.state_machine"), "should contain state_machine op");
+        assert!(out.contains("scf.execute_region"), "should contain state_machine op");
         assert!(out.contains("^idle"), "should contain idle region");
         assert!(out.contains("^running"), "should contain running region");
-        assert!(out.contains("dataflow.message_field"), "should contain message_field op");
+        assert!(out.contains("builtin.extract_field"), "should contain message_field op");
         assert!(out.contains("speed"), "should reference speed field");
     }
 

--- a/mlir-codegen/tests/multi_target.rs
+++ b/mlir-codegen/tests/multi_target.rs
@@ -182,26 +182,26 @@ fn test_rp2040_adc_pwm_graph() {
 
     // Verify the MLIR contains the expected hardware ops
     assert!(
-        mlir.contains("dataflow.adc_read"),
-        "MLIR should contain dataflow.adc_read for the ADC source; got:\n{mlir}"
+        mlir.contains("func.call @adc_read"),
+        "MLIR should contain func.call @adc_read for the ADC source; got:\n{mlir}"
     );
     assert!(
-        mlir.contains("dataflow.pwm_write"),
-        "MLIR should contain dataflow.pwm_write for the PWM sink; got:\n{mlir}"
+        mlir.contains("func.call @pwm_write"),
+        "MLIR should contain func.call @pwm_write for the PWM sink; got:\n{mlir}"
     );
     assert!(
-        mlir.contains("dataflow.gain"),
-        "MLIR should contain dataflow.gain for the scaling block; got:\n{mlir}"
+        mlir.contains("arith.mulf"),
+        "MLIR should contain arith.mulf for the scaling block; got:\n{mlir}"
     );
 
-    // Verify channel configuration appears in the attributes
+    // Verify channel configuration appears in the function names
     assert!(
-        mlir.contains("channel = 0 : i32"),
-        "adc_read should have channel = 0 attribute; got:\n{mlir}"
+        mlir.contains("@adc_read_0"),
+        "adc_read should have channel 0 in function name; got:\n{mlir}"
     );
     assert!(
-        mlir.contains("channel = 1 : i32"),
-        "pwm_write should have channel = 1 attribute; got:\n{mlir}"
+        mlir.contains("@pwm_write_1"),
+        "pwm_write should have channel 1 in function name; got:\n{mlir}"
     );
 
     // Verify gain factor
@@ -212,7 +212,7 @@ fn test_rp2040_adc_pwm_graph() {
 
     // Verify wiring: gain should reference adc output SSA name
     assert!(
-        mlir.contains("dataflow.gain(%v1_p0)"),
+        mlir.contains("arith.mulf %v1_p0"),
         "gain input should be wired to adc output %v1_p0; got:\n{mlir}"
     );
 
@@ -264,20 +264,20 @@ fn test_stm32_multi_block_graph() {
 
     // Verify all four op types are present
     assert!(
-        mlir.contains("dataflow.constant"),
-        "MLIR should contain dataflow.constant; got:\n{mlir}"
+        mlir.contains("arith.constant"),
+        "MLIR should contain arith.constant; got:\n{mlir}"
     );
     assert!(
-        mlir.contains("dataflow.gain"),
-        "MLIR should contain dataflow.gain; got:\n{mlir}"
+        mlir.contains("arith.mulf"),
+        "MLIR should contain arith.mulf for gain; got:\n{mlir}"
     );
     assert!(
-        mlir.contains("dataflow.subtract"),
-        "MLIR should contain dataflow.subtract; got:\n{mlir}"
+        mlir.contains("arith.subf"),
+        "MLIR should contain arith.subf for subtract; got:\n{mlir}"
     );
     assert!(
-        mlir.contains("dataflow.clamp"),
-        "MLIR should contain dataflow.clamp; got:\n{mlir}"
+        mlir.contains("arith.minimumf") || mlir.contains("arith.maximumf"),
+        "MLIR should contain arith.minimumf/maximumf for clamp; got:\n{mlir}"
     );
 
     // Verify the constant values appear
@@ -298,13 +298,13 @@ fn test_stm32_multi_block_graph() {
 
     // Verify wiring: subtract should reference both setpoint and gain outputs
     assert!(
-        mlir.contains("dataflow.subtract(%v1_p0, %v3_p0)"),
+        mlir.contains("arith.subf %v1_p0, %v3_p0"),
         "subtract should be wired to setpoint (%v1_p0) and gain output (%v3_p0); got:\n{mlir}"
     );
 
     // Verify wiring: clamp should reference subtract output
     assert!(
-        mlir.contains("dataflow.clamp(%v4_p0)"),
+        mlir.contains("arith.minimumf %v4_p0"),
         "clamp should be wired to subtract output %v4_p0; got:\n{mlir}"
     );
 }

--- a/mlir-codegen/tests/pipeline_integration.rs
+++ b/mlir-codegen/tests/pipeline_integration.rs
@@ -63,7 +63,7 @@ fn test_pipeline_default_config() {
 
     // The MLIR text should always be produced regardless of external tool availability
     assert!(
-        output.mlir_text.contains("dataflow.constant"),
+        output.mlir_text.contains("arith.constant"),
         "pipeline output should contain the lowered constant op"
     );
     assert!(
@@ -95,12 +95,12 @@ fn test_pipeline_multi_block_chain() {
         mlir_codegen::pipeline::run_pipeline(&snap, &config).expect("run_pipeline should succeed");
 
     assert!(
-        output.mlir_text.contains("dataflow.constant"),
+        output.mlir_text.contains("arith.constant"),
         "MLIR should contain the constant op; got:\n{}",
         output.mlir_text
     );
     assert!(
-        output.mlir_text.contains("dataflow.gain"),
+        output.mlir_text.contains("arith.mulf"),
         "MLIR should contain the gain op; got:\n{}",
         output.mlir_text
     );
@@ -111,7 +111,7 @@ fn test_pipeline_multi_block_chain() {
         output.mlir_text
     );
     assert!(
-        output.mlir_text.contains("dataflow.gain(%v1_p0)"),
+        output.mlir_text.contains("arith.mulf %v1_p0"),
         "gain op should be wired to constant output; got:\n{}",
         output.mlir_text
     );

--- a/module-traits/src/function_def.rs
+++ b/module-traits/src/function_def.rs
@@ -1,0 +1,393 @@
+//! Data-driven function definitions for the dataflow engine.
+//!
+//! A [`FunctionDef`] is a schema that fully describes a block's identity,
+//! ports, configuration parameters, and evaluation semantics.  Instead of
+//! one Rust struct per block type, the engine stores a flat registry of
+//! `FunctionDef` values and instantiates generic [`super::Module`] impls
+//! from them.
+//!
+//! The WASM layer exposes the full registry to JavaScript so the frontend
+//! can build its palette, config panels, and validation from the schema
+//! alone — no hardcoded type mirrors needed on the JS side.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use serde::{Deserialize, Serialize};
+
+use crate::value::PortKind;
+
+/// How a function computes its outputs from inputs and params.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum FunctionOp {
+    /// out = constant value (param "value")
+    Constant,
+    /// out = in * param("gain")
+    Gain,
+    /// out = a + b
+    Add,
+    /// out = a * b
+    Multiply,
+    /// out = a - b
+    Subtract,
+    /// out = clamp(in, param("min"), param("max"))
+    Clamp,
+    /// out = select(cond, a, b) — if cond > 0 then a else b
+    Select,
+    /// Hardware read — bound to a typed channel at deploy time
+    ChannelRead,
+    /// Hardware write — bound to a typed channel at deploy time
+    ChannelWrite,
+    /// Accumulate float samples into a series (UI-only visualization)
+    PlotAccum,
+    /// Encode value to JSON text
+    JsonEncode,
+    /// Decode JSON text to value
+    JsonDecode,
+    /// Pub/sub source — reads from a named topic
+    PubSubSource,
+    /// Pub/sub sink — writes to a named topic
+    PubSubSink,
+}
+
+/// A parameter definition for a function's config.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ParamDef {
+    /// Parameter name (e.g., "gain", "channel", "topic").
+    pub name: String,
+    /// The kind of value this parameter takes.
+    pub kind: ParamKind,
+    /// Default value as a JSON-compatible string.
+    pub default: String,
+}
+
+/// The type of a configuration parameter.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ParamKind {
+    Float,
+    Int,
+    String,
+    Bool,
+}
+
+/// Port definition within a function def.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FuncPortDef {
+    pub name: String,
+    pub kind: PortKind,
+}
+
+/// A complete, data-driven function definition.
+///
+/// This is the single source of truth for a block type's schema.
+/// The WASM layer serializes the full registry to JS so the frontend
+/// can build palette, config panels, and validation without
+/// hardcoding block-specific knowledge.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FunctionDef {
+    /// Unique type identifier (e.g., "constant", "gain", "adc_read").
+    pub id: String,
+    /// Human-readable display name.
+    pub display_name: String,
+    /// Category for palette grouping (e.g., "Math", "Sources", "I/O").
+    pub category: String,
+    /// The operation this function performs.
+    pub op: FunctionOp,
+    /// Input port definitions.
+    pub inputs: Vec<FuncPortDef>,
+    /// Output port definitions.
+    pub outputs: Vec<FuncPortDef>,
+    /// Configurable parameters with defaults.
+    pub params: Vec<ParamDef>,
+    /// MLIR dialect op this maps to (e.g., "arith.addf", "arith.mulf").
+    /// Used by codegen to emit the correct MLIR op.
+    pub mlir_op: Option<String>,
+}
+
+impl FuncPortDef {
+    pub fn new(name: &str, kind: PortKind) -> Self {
+        Self {
+            name: String::from(name),
+            kind,
+        }
+    }
+}
+
+impl ParamDef {
+    pub fn float(name: &str, default: f64) -> Self {
+        Self {
+            name: String::from(name),
+            kind: ParamKind::Float,
+            default: alloc::format!("{default}"),
+        }
+    }
+
+    pub fn int(name: &str, default: i64) -> Self {
+        Self {
+            name: String::from(name),
+            kind: ParamKind::Int,
+            default: alloc::format!("{default}"),
+        }
+    }
+
+    pub fn string(name: &str, default: &str) -> Self {
+        Self {
+            name: String::from(name),
+            kind: ParamKind::String,
+            default: String::from(default),
+        }
+    }
+}
+
+/// Build the complete builtin function registry.
+///
+/// This is the single source of truth for all block types.
+/// WASM serializes this to JS; MLIR codegen reads `mlir_op` from it.
+pub fn builtin_function_defs() -> Vec<FunctionDef> {
+    alloc::vec![
+        // ── Sources ──────────────────────────────────────────
+        FunctionDef {
+            id: s("constant"),
+            display_name: s("Constant"),
+            category: s("Sources"),
+            op: FunctionOp::Constant,
+            inputs: alloc::vec![],
+            outputs: alloc::vec![FuncPortDef::new("out", PortKind::Float)],
+            params: alloc::vec![ParamDef::float("value", 1.0)],
+            mlir_op: Some(s("arith.constant")),
+        },
+        // ── Math ─────────────────────────────────────────────
+        FunctionDef {
+            id: s("gain"),
+            display_name: s("Gain"),
+            category: s("Math"),
+            op: FunctionOp::Gain,
+            inputs: alloc::vec![FuncPortDef::new("in", PortKind::Float)],
+            outputs: alloc::vec![FuncPortDef::new("out", PortKind::Float)],
+            params: alloc::vec![ParamDef::float("gain", 1.0)],
+            mlir_op: Some(s("arith.mulf")),
+        },
+        FunctionDef {
+            id: s("add"),
+            display_name: s("Add"),
+            category: s("Math"),
+            op: FunctionOp::Add,
+            inputs: alloc::vec![
+                FuncPortDef::new("a", PortKind::Float),
+                FuncPortDef::new("b", PortKind::Float),
+            ],
+            outputs: alloc::vec![FuncPortDef::new("out", PortKind::Float)],
+            params: alloc::vec![],
+            mlir_op: Some(s("arith.addf")),
+        },
+        FunctionDef {
+            id: s("multiply"),
+            display_name: s("Multiply"),
+            category: s("Math"),
+            op: FunctionOp::Multiply,
+            inputs: alloc::vec![
+                FuncPortDef::new("a", PortKind::Float),
+                FuncPortDef::new("b", PortKind::Float),
+            ],
+            outputs: alloc::vec![FuncPortDef::new("out", PortKind::Float)],
+            params: alloc::vec![],
+            mlir_op: Some(s("arith.mulf")),
+        },
+        FunctionDef {
+            id: s("subtract"),
+            display_name: s("Subtract"),
+            category: s("Math"),
+            op: FunctionOp::Subtract,
+            inputs: alloc::vec![
+                FuncPortDef::new("a", PortKind::Float),
+                FuncPortDef::new("b", PortKind::Float),
+            ],
+            outputs: alloc::vec![FuncPortDef::new("out", PortKind::Float)],
+            params: alloc::vec![],
+            mlir_op: Some(s("arith.subf")),
+        },
+        FunctionDef {
+            id: s("clamp"),
+            display_name: s("Clamp"),
+            category: s("Math"),
+            op: FunctionOp::Clamp,
+            inputs: alloc::vec![FuncPortDef::new("in", PortKind::Float)],
+            outputs: alloc::vec![FuncPortDef::new("out", PortKind::Float)],
+            params: alloc::vec![
+                ParamDef::float("min", 0.0),
+                ParamDef::float("max", 1.0),
+            ],
+            mlir_op: None, // clamp = max(min, min(max, x)) — compound arith
+        },
+        FunctionDef {
+            id: s("select"),
+            display_name: s("Select"),
+            category: s("Math"),
+            op: FunctionOp::Select,
+            inputs: alloc::vec![
+                FuncPortDef::new("cond", PortKind::Float),
+                FuncPortDef::new("a", PortKind::Float),
+                FuncPortDef::new("b", PortKind::Float),
+            ],
+            outputs: alloc::vec![FuncPortDef::new("out", PortKind::Float)],
+            params: alloc::vec![],
+            mlir_op: Some(s("arith.select")),
+        },
+        // ── I/O Channels (bound to BSP at deploy time) ──────
+        FunctionDef {
+            id: s("channel_read"),
+            display_name: s("Channel Read"),
+            category: s("I/O"),
+            op: FunctionOp::ChannelRead,
+            inputs: alloc::vec![],
+            outputs: alloc::vec![FuncPortDef::new("value", PortKind::Float)],
+            params: alloc::vec![
+                ParamDef::string("channel", ""),
+                ParamDef::string("peripheral", ""),
+            ],
+            mlir_op: Some(s("func.call")),
+        },
+        FunctionDef {
+            id: s("channel_write"),
+            display_name: s("Channel Write"),
+            category: s("I/O"),
+            op: FunctionOp::ChannelWrite,
+            inputs: alloc::vec![FuncPortDef::new("value", PortKind::Float)],
+            outputs: alloc::vec![],
+            params: alloc::vec![
+                ParamDef::string("channel", ""),
+                ParamDef::string("peripheral", ""),
+            ],
+            mlir_op: Some(s("func.call")),
+        },
+        // ── Visualization ────────────────────────────────────
+        FunctionDef {
+            id: s("plot"),
+            display_name: s("Plot"),
+            category: s("Visualization"),
+            op: FunctionOp::PlotAccum,
+            inputs: alloc::vec![FuncPortDef::new("in", PortKind::Float)],
+            outputs: alloc::vec![FuncPortDef::new("series", PortKind::Series)],
+            params: alloc::vec![ParamDef::int("max_samples", 500)],
+            mlir_op: None,
+        },
+        // ── Serialization ────────────────────────────────────
+        FunctionDef {
+            id: s("json_encode"),
+            display_name: s("JSON Encode"),
+            category: s("Serialization"),
+            op: FunctionOp::JsonEncode,
+            inputs: alloc::vec![FuncPortDef::new("in", PortKind::Any)],
+            outputs: alloc::vec![FuncPortDef::new("out", PortKind::Text)],
+            params: alloc::vec![],
+            mlir_op: None,
+        },
+        FunctionDef {
+            id: s("json_decode"),
+            display_name: s("JSON Decode"),
+            category: s("Serialization"),
+            op: FunctionOp::JsonDecode,
+            inputs: alloc::vec![FuncPortDef::new("in", PortKind::Text)],
+            outputs: alloc::vec![FuncPortDef::new("out", PortKind::Any)],
+            params: alloc::vec![],
+            mlir_op: None,
+        },
+        // ── Pub/Sub ──────────────────────────────────────────
+        FunctionDef {
+            id: s("pubsub_source"),
+            display_name: s("PubSub Source"),
+            category: s("Pub/Sub"),
+            op: FunctionOp::PubSubSource,
+            inputs: alloc::vec![],
+            outputs: alloc::vec![FuncPortDef::new("value", PortKind::Float)],
+            params: alloc::vec![
+                ParamDef::string("topic", "default"),
+                ParamDef::string("port_kind", "Float"),
+            ],
+            mlir_op: Some(s("func.call")),
+        },
+        FunctionDef {
+            id: s("pubsub_sink"),
+            display_name: s("PubSub Sink"),
+            category: s("Pub/Sub"),
+            op: FunctionOp::PubSubSink,
+            inputs: alloc::vec![FuncPortDef::new("value", PortKind::Float)],
+            outputs: alloc::vec![],
+            params: alloc::vec![
+                ParamDef::string("topic", "default"),
+                ParamDef::string("port_kind", "Float"),
+            ],
+            mlir_op: Some(s("func.call")),
+        },
+    ]
+}
+
+fn s(v: &str) -> String {
+    String::from(v)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_registry_has_entries() {
+        let defs = builtin_function_defs();
+        assert!(defs.len() >= 10);
+    }
+
+    #[test]
+    fn all_ids_unique() {
+        let defs = builtin_function_defs();
+        let mut ids: Vec<_> = defs.iter().map(|d| &d.id).collect();
+        let len_before = ids.len();
+        ids.sort();
+        ids.dedup();
+        assert_eq!(ids.len(), len_before, "duplicate function def ids found");
+    }
+
+    #[test]
+    fn constant_has_arith_mlir_op() {
+        let defs = builtin_function_defs();
+        let c = defs.iter().find(|d| d.id == "constant").unwrap();
+        assert_eq!(c.mlir_op.as_deref(), Some("arith.constant"));
+    }
+
+    #[test]
+    fn add_has_arith_addf() {
+        let defs = builtin_function_defs();
+        let a = defs.iter().find(|d| d.id == "add").unwrap();
+        assert_eq!(a.mlir_op.as_deref(), Some("arith.addf"));
+    }
+
+    #[test]
+    fn channel_read_uses_func_call() {
+        let defs = builtin_function_defs();
+        let cr = defs.iter().find(|d| d.id == "channel_read").unwrap();
+        assert_eq!(cr.mlir_op.as_deref(), Some("func.call"));
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let defs = builtin_function_defs();
+        let json = serde_json::to_string(&defs).unwrap();
+        let restored: Vec<FunctionDef> = serde_json::from_str(&json).unwrap();
+        assert_eq!(defs.len(), restored.len());
+        assert_eq!(defs[0].id, restored[0].id);
+    }
+
+    #[test]
+    fn param_def_constructors() {
+        let f = ParamDef::float("gain", 2.5);
+        assert_eq!(f.name, "gain");
+        assert_eq!(f.kind, ParamKind::Float);
+        assert_eq!(f.default, "2.5");
+
+        let i = ParamDef::int("channel", 0);
+        assert_eq!(i.kind, ParamKind::Int);
+
+        let s = ParamDef::string("topic", "hello");
+        assert_eq!(s.kind, ParamKind::String);
+        assert_eq!(s.default, "hello");
+    }
+}

--- a/module-traits/src/lib.rs
+++ b/module-traits/src/lib.rs
@@ -17,6 +17,7 @@ extern crate alloc;
 pub mod analysis;
 pub mod codegen_trait;
 pub mod deployment;
+pub mod function_def;
 pub mod hardware;
 pub mod inventory;
 pub mod module;
@@ -26,6 +27,9 @@ pub mod value;
 
 pub use analysis::{AnalysisMetadata, AnalysisModel};
 pub use codegen_trait::Codegen;
+pub use function_def::{
+    FuncPortDef, FunctionDef, FunctionOp, ParamDef, ParamKind, builtin_function_defs,
+};
 pub use module::Module;
 pub use sim::{SimModel, SimPeripherals};
 pub use tick::Tick;

--- a/www/src/dataflow/graph.ts
+++ b/www/src/dataflow/graph.ts
@@ -4,8 +4,9 @@ import {
   dataflow_new, dataflow_destroy, dataflow_add_block, dataflow_remove_block,
   dataflow_update_block, dataflow_connect, dataflow_disconnect, dataflow_advance,
   dataflow_run, dataflow_set_speed, dataflow_snapshot, dataflow_block_types,
+  dataflow_function_defs, mcu_families, mcu_definition, mcu_pins, mcu_peripherals,
 } from '../../pkg/rustsim.js';
-import type { GraphSnapshot, BlockTypeInfo, NodePosition } from './types.js';
+import type { GraphSnapshot, BlockTypeInfo, NodePosition, FunctionDef, McuDef } from './types.js';
 import type { TelemetryPublisher } from './telemetry.js';
 import type { SavedProject } from './storage.js';
 
@@ -128,5 +129,31 @@ export class DataflowManager {
 
   static blockTypes(): BlockTypeInfo[] {
     return JSON.parse(dataflow_block_types());
+  }
+
+  /** Get the full function definition registry from WASM.
+   *  This is the single source of truth for all block schemas. */
+  static functionDefs(): FunctionDef[] {
+    return dataflow_function_defs();
+  }
+
+  /** List supported MCU target families. */
+  static mcuFamilies(): string[] {
+    return mcu_families();
+  }
+
+  /** Get the full MCU definition for a target family (pins, peripherals, etc). */
+  static mcuDefinition(family: string): McuDef {
+    return mcu_definition(family);
+  }
+
+  /** Get just the pin definitions for a target family. */
+  static mcuPins(family: string): import('./types.js').PinDef[] {
+    return mcu_pins(family);
+  }
+
+  /** Get peripheral instances for a target family. */
+  static mcuPeripherals(family: string): import('./types.js').PeripheralInst[] {
+    return mcu_peripherals(family);
   }
 }

--- a/www/src/dataflow/index.ts
+++ b/www/src/dataflow/index.ts
@@ -5,7 +5,7 @@ import { $, $btn, $input } from '../dom.js';
 import { DataflowManager } from './graph.js';
 import { DataflowEditor } from './editor.js';
 import { drawPlot } from './plot.js';
-import { DEFAULT_CONFIGS } from './palette.js';
+import { DEFAULT_CONFIGS, initDefaultConfigs } from './palette.js';
 import { createZip } from './zip.js';
 import { HilClient } from './hil-client.js';
 import { renderPinTable } from './pin-table.js';
@@ -32,6 +32,14 @@ let triggerAutoSave: (() => void) | null = null;
 let telemetry: TelemetryPublisher | null = null;
 
 export function initDataflow(): void {
+  // Initialize default configs from WASM function def schema
+  try {
+    const defs = DataflowManager.functionDefs();
+    initDefaultConfigs(defs);
+  } catch (_) {
+    // Fall back to legacy hardcoded configs if WASM API not available
+  }
+
   mgr = new DataflowManager(0.01);
   const container = $('dataflow-workspace') as HTMLDivElement;
   editor = new DataflowEditor(container, mgr);

--- a/www/src/dataflow/palette.ts
+++ b/www/src/dataflow/palette.ts
@@ -1,13 +1,29 @@
 /** Searchable block type picker for the dataflow editor. */
 
-import type { BlockTypeInfo } from './types.js';
+import type { BlockTypeInfo, FunctionDef } from './types.js';
 import type { DataflowManager } from './graph.js';
 
-export const DEFAULT_CONFIGS: Record<string, Record<string, unknown>> = {
-  constant: { value: 1.0 },
-  gain: { op: 'Gain', param1: 1.0, param2: 0.0 },
-  clamp: { op: 'Clamp', param1: 0.0, param2: 100.0 },
-  plot: { max_samples: 500 },
+/** Build default configs from function def param defaults.
+ *  Falls back to legacy hardcoded configs for block types not in the registry. */
+export function buildDefaultConfigs(defs: FunctionDef[]): Record<string, Record<string, unknown>> {
+  const configs: Record<string, Record<string, unknown>> = {};
+  for (const def of defs) {
+    const cfg: Record<string, unknown> = {};
+    for (const p of def.params) {
+      switch (p.kind) {
+        case 'Float': cfg[p.name] = parseFloat(p.default) || 0; break;
+        case 'Int': cfg[p.name] = parseInt(p.default, 10) || 0; break;
+        case 'Bool': cfg[p.name] = p.default === 'true'; break;
+        case 'String': cfg[p.name] = p.default; break;
+      }
+    }
+    configs[def.id] = cfg;
+  }
+  return configs;
+}
+
+/** Legacy defaults for block types not yet in the FunctionDef registry. */
+const LEGACY_CONFIGS: Record<string, Record<string, unknown>> = {
   udp_source: { address: '127.0.0.1:9000' },
   udp_sink: { address: '127.0.0.1:9001' },
   adc_source: { channel: 0, resolution_bits: 12 },
@@ -16,14 +32,21 @@ export const DEFAULT_CONFIGS: Record<string, Record<string, unknown>> = {
   gpio_in: { pin: 2 },
   uart_tx: { port: 0, baud: 115200 },
   uart_rx: { port: 0, baud: 115200 },
-  pubsub_source: { topic: 'default', port_kind: 'Float' },
-  pubsub_sink: { topic: 'default', port_kind: 'Float' },
   state_machine: { states: ['idle'], initial: 'idle', transitions: [], input_topics: [], output_topics: [] },
   encoder: { channel: 0 },
   ssd1306_display: { i2c_bus: 0, address: 60 },
   tmc2209_stepper: { uart_port: 0, uart_addr: 0, steps_per_rev: 200, microsteps: 16 },
   tmc2209_stallguard: { uart_port: 0, uart_addr: 0, threshold: 50 },
 };
+
+/** Merged default configs: schema-driven from WASM + legacy fallbacks. */
+export let DEFAULT_CONFIGS: Record<string, Record<string, unknown>> = { ...LEGACY_CONFIGS };
+
+/** Initialize DEFAULT_CONFIGS from WASM function defs.
+ *  Call this once after WASM is loaded. */
+export function initDefaultConfigs(defs: FunctionDef[]): void {
+  DEFAULT_CONFIGS = { ...LEGACY_CONFIGS, ...buildDefaultConfigs(defs) };
+}
 
 /** Show palette at screen position, create block at world position. */
 export function showPalette(

--- a/www/src/dataflow/types.ts
+++ b/www/src/dataflow/types.ts
@@ -1,8 +1,65 @@
-/** Dataflow graph types mirroring the Rust structures. */
+/** Dataflow graph types — schema-driven from WASM. */
 
 export interface PortDef {
   name: string;
   kind: string; // "Float" | "Bytes" | "Text" | "Series" | "Any"
+}
+
+// -- Schema types (pushed from WASM) --
+
+export type ParamKind = 'Float' | 'Int' | 'String' | 'Bool';
+
+export interface ParamDef {
+  name: string;
+  kind: ParamKind;
+  default: string;
+}
+
+export interface FuncPortDef {
+  name: string;
+  kind: string;
+}
+
+export interface FunctionDef {
+  id: string;
+  display_name: string;
+  category: string;
+  op: string;
+  inputs: FuncPortDef[];
+  outputs: FuncPortDef[];
+  params: ParamDef[];
+  mlir_op: string | null;
+}
+
+// -- MCU / BSP types (pushed from WASM) --
+
+export interface PinDef {
+  name: string;
+  port: string;
+  number: number;
+  alt_functions: AltFunction[];
+  adc_channel: number | null;
+  five_v_tolerant: boolean;
+}
+
+export interface AltFunction {
+  af: number;
+  peripheral: string;
+  signal: string;
+}
+
+export interface PeripheralInst {
+  name: string;
+  kind: string;
+  signals: { signal: string; pin: string; af: number | null }[];
+}
+
+export interface McuDef {
+  family: string;
+  part_number: string;
+  display_name: string;
+  pins: PinDef[];
+  peripherals: PeripheralInst[];
 }
 
 export interface ValueFloat { type: 'Float'; data: number }


### PR DESCRIPTION
Replace per-block Rust structs with a single DataDrivenBlock parameterized
by FunctionDef schemas. WASM now owns the full block registry and pushes
schema, naming, and UI metadata to JS — the frontend derives its palette,
config panels, and validation from WASM rather than maintaining hardcoded
type mirrors.

Key changes:
- Add FunctionDef/FuncPortDef/ParamDef types in module-traits with builtin
  registry covering constant, gain, add, multiply, subtract, clamp, select,
  channel_read, channel_write, plot, json_encode/decode, pubsub_source/sink
- Add DataDrivenBlock in rustsim that implements Module+Tick generically
  from any FunctionDef + JSON config, with legacy config backward compat
- Add WASM APIs: dataflow_function_defs(), mcu_families(), mcu_definition(),
  mcu_pins(), mcu_peripherals() — frontend BSP config reads pin schemas
- Align MLIR codegen with standard dialects: math ops use arith.addf/mulf/
  subf/constant, I/O uses func.call @channel_name(), state machines use
  scf.execute_region, clamp decomposes to arith.minimumf/maximumf
- Update TypeScript types.ts with FunctionDef, McuDef, PinDef, ParamDef
- palette.ts derives DEFAULT_CONFIGS from WASM schema at init time
- graph.ts exposes functionDefs(), mcuFamilies(), mcuDefinition() etc.

https://claude.ai/code/session_0147MvqCMduQNQKuMEjFRnRX